### PR TITLE
WIP: switch from 3D shmem kernel to 2D kernel when N is 9+

### DIFF
--- a/libs/core/platformProperties.cpp
+++ b/libs/core/platformProperties.cpp
@@ -61,6 +61,7 @@ void platform_t::DeviceProperties(){
   if(device.mode()=="Serial") {
     props["compiler_flags"] += "-O3 ";
     props["compiler_flags"] += "-g "; //debugging
+    props["defines/OCCA_USE_SERIAL"] = 1;
   }
 
   if(device.mode()=="CUDA"){ // add backend compiler optimization for CUDA
@@ -70,6 +71,7 @@ void platform_t::DeviceProperties(){
     props["compiler_flags"] += "--use_fast_math ";
     props["compiler_flags"] += "--fmad=true "; // compiler option for cuda
     props["compiler_flags"] += "-Xptxas -dlcm=ca";
+    props["defines/OCCA_USE_CUDA"] = 1;
   }
 
   if(device.mode()=="OpenCL"){ // add backend compiler optimization for OPENCL
@@ -79,6 +81,7 @@ void platform_t::DeviceProperties(){
     props["compiler_flags"] += " -cl-no-signed-zeros ";
     props["compiler_flags"] += " -cl-unsafe-math-optimizations ";
     props["compiler_flags"] += " -cl-fast-relaxed-math ";
+    props["defines/OCCA_USE_OPENCL"] = 1;
   }
 
   if(device.mode()=="HIP"){ // add backend compiler optimization for HIP
@@ -87,5 +90,6 @@ void platform_t::DeviceProperties(){
     props["compiler_flags"] += " -funsafe-math-optimizations ";
     props["compiler_flags"] += " -ffast-math ";
     props["compiler_flags"] += "--gpu-max-threads-per-block=256";
+    props["defines/OCCA_USE_HIP"] = 1;
   }
 }

--- a/okl/hipBoneAx.okl
+++ b/okl/hipBoneAx.okl
@@ -24,9 +24,14 @@ SOFTWARE.
 
 */
 
+#if p_N<=8
+#define USE_3D_SHMEM 1
+#else
 #define USE_3D_SHMEM 0
+#endif
 
 #if !USE_3D_SHMEM
+
 
 //This kernel processes 2D slices of the element in shmem and uses register arrays
 // to store the element itself. May be slower for low order but allows us to run
@@ -136,7 +141,10 @@ SOFTWARE.
     }
 
     // Layer by layer
-    // #pragma unroll 1
+#if OCCA_USE_CUDA==1
+    // only force some type of unrolling in CUDA mode
+    #pragma unroll p_Nq
+#endif
     for(int k = 0;k < p_Nq; k++){
 
       for(int es=0;es<p_NelementsPerBlk;++es;@inner(2)){

--- a/run.sh
+++ b/run.sh
@@ -39,21 +39,21 @@ make -j `nproc`
 
 echo "Running hipBone..."
 
-mpirun -np $np hipBone -m $mode -nx 126 -ny 126 -nz 126 -p 1
-mpirun -np $np hipBone -m $mode -nx  63 -ny  63 -nz  63 -p 2
-mpirun -np $np hipBone -m $mode -nx  42 -ny  42 -nz  42 -p 3
-mpirun -np $np hipBone -m $mode -nx  32 -ny  32 -nz  32 -p 4
-mpirun -np $np hipBone -m $mode -nx  26 -ny  26 -nz  26 -p 5
-mpirun -np $np hipBone -m $mode -nx  21 -ny  21 -nz  21 -p 6
-mpirun -np $np hipBone -m $mode -nx  18 -ny  18 -nz  18 -p 7
-mpirun -np $np hipBone -m $mode -nx  16 -ny  16 -nz  16 -p 8
-mpirun -np $np hipBone -m $mode -nx  14 -ny  14 -nz  14 -p 9
-mpirun -np $np hipBone -m $mode -nx  13 -ny  13 -nz  13 -p 10
-mpirun -np $np hipBone -m $mode -nx  12 -ny  12 -nz  12 -p 11
-mpirun -np $np hipBone -m $mode -nx  11 -ny  11 -nz  11 -p 12
-mpirun -np $np hipBone -m $mode -nx  10 -ny  10 -nz  10 -p 13
-mpirun -np $np hipBone -m $mode -nx   9 -ny   9 -nz   9 -p 14
-mpirun -np $np hipBone -m $mode -nx   9 -ny   9 -nz   9 -p 15
+mpirun -np $np ./hipBone -m $mode -nx 126 -ny 126 -nz 126 -p 1
+mpirun -np $np ./hipBone -m $mode -nx  63 -ny  63 -nz  63 -p 2
+mpirun -np $np ./hipBone -m $mode -nx  42 -ny  42 -nz  42 -p 3
+mpirun -np $np ./hipBone -m $mode -nx  32 -ny  32 -nz  32 -p 4
+mpirun -np $np ./hipBone -m $mode -nx  26 -ny  26 -nz  26 -p 5
+mpirun -np $np ./hipBone -m $mode -nx  21 -ny  21 -nz  21 -p 6
+mpirun -np $np ./hipBone -m $mode -nx  18 -ny  18 -nz  18 -p 7
+mpirun -np $np ./hipBone -m $mode -nx  16 -ny  16 -nz  16 -p 8
+mpirun -np $np ./hipBone -m $mode -nx  14 -ny  14 -nz  14 -p 9
+mpirun -np $np ./hipBone -m $mode -nx  13 -ny  13 -nz  13 -p 10
+mpirun -np $np ./hipBone -m $mode -nx  12 -ny  12 -nz  12 -p 11
+mpirun -np $np ./hipBone -m $mode -nx  11 -ny  11 -nz  11 -p 12
+mpirun -np $np ./hipBone -m $mode -nx  10 -ny  10 -nz  10 -p 13
+mpirun -np $np ./hipBone -m $mode -nx   9 -ny   9 -nz   9 -p 14
+mpirun -np $np ./hipBone -m $mode -nx   9 -ny   9 -nz   9 -p 15
 
 #
 # Noel Chalmers


### PR DESCRIPTION
This PR:

1. Adds ```./``` to the executable in ```run.scr```
2. Switches between the 2D and 3D matvec kernel based on polynomial degree.
3. Adds compiler defines ```OCCA_USE_CUDA```, ```OCCA_USE_HIP```, ```OCCA_USE_OPENCL```, ```OCCA_USE_SERIAL``` in the core platform properties.
4. Unrolls the big  k loop in the 2D matvec kernel when ```OCCA_USE_CUDA==1```

The benchmark throughput on NVIDIA Titan V (using OCCA:CUDA) and AMD Radeon VII is now fairly uniform in polynomial degree.