### PR TITLE
Fix narrowing conversion for `NGlobal`

### DIFF
--- a/src/run.cpp
+++ b/src/run.cpp
@@ -33,7 +33,7 @@ void hipBone_t::Run(){
   dlong Nhalo = mesh.ogsMasked->NgatherHalo;
   linearSolver_t *linearSolver = new cg(platform, N, Nhalo);
 
-  dlong NGlobal = mesh.ogsMasked->NgatherGlobal;
+  hlong NGlobal = mesh.ogsMasked->NgatherGlobal;
   dlong NLocal = mesh.Np*mesh.Nelements;
 
   //create occa buffers


### PR DESCRIPTION
This conversion was incorrect since `mesh.ogsMasked->NgatherGlobal` is
already of type `hlong`.  Converting it to a `dlong` simply truncated digits
making any further arithmetic with the value incorrect.