### PR TITLE
Set rpath for user-specified OpenBLAS

### DIFF
--- a/make.top
+++ b/make.top
@@ -46,7 +46,7 @@ export HIPBONE_LD = mpic++
 
 export HIPBONE_INCLUDES=-I${HIPBONE_INCLUDE_DIR} -I${OCCA_DIR}/include
 export HIPBONE_LIBS= ${HIPBONE_BLAS_LIB}  \
-                     -Wl,-rpath,$(OCCA_DIR)/lib -L$(OCCA_DIR)/lib -locca
+                     -Wl,-rpath,$(OCCA_DIR)/lib -Wl,-rpath,${OPENBLAS_DIR} -L$(OCCA_DIR)/lib -locca
 
 ifneq (,${debug})
   export HIPBONE_CFLAGS=-O0 -g -Wall -Wshadow -Wno-unused-function -Wno-unknown-pragmas


### PR DESCRIPTION
In environments such as Conda where libraries are not installed in standard directories, `ldd ./hipBone` is unable to find the right `libopenblas`.

(adding conda environment's lib path to `LD_LIBRARY_PATH` creates other issues and is also not recommended by conda)