### PR TITLE
Add library of parallel primitives and use them in ogs setup

### DIFF
--- a/include/comm.hpp
+++ b/include/comm.hpp
@@ -548,6 +548,7 @@ class comm_t {
 
   void Wait(request_t &request) const;
   void Waitall(const int count, memory<request_t> &requests) const;
+  void Waitall(const int count, request_t* requests) const;
   void Barrier() const;
 
   static void GetProcessorName(char* name, int &namelen) {

--- a/include/ogs/ogsBase.hpp
+++ b/include/ogs/ogsBase.hpp
@@ -35,12 +35,7 @@ namespace ogs {
 
 //forward declarations
 class ogsOperator_t;
-class ogsFusedOperator_t;
 class ogsExchange_t;
-
-struct parallelNode_t;
-
-class halo_t;
 
 class ogsBase_t {
 public:
@@ -84,21 +79,34 @@ protected:
   void AssertGatherDefined();
 
 private:
-  void FindSharedNodes(const dlong Nids,
-                       memory<parallelNode_t> &nodes,
-                       const int verbose);
+  void FindSharedGroups(const dlong Nids,
+                        memory<hlong> baseIds,
+                        memory<int> sharedFlag,
+                        const int verbose);
+  void ConstructGatherOperators(const dlong Nlocal,
+                                const memory<dlong> localRowIds,
+                                const memory<dlong> localColIds,
+                                const memory<hlong> localBaseIds,
+                                const dlong Nhalo,
+                                const memory<dlong> haloRowIds,
+                                const memory<dlong> haloColIds,
+                                const memory<hlong> haloBaseIds);
 
-  void ConstructSharedNodes(const dlong Nids,
-                           memory<parallelNode_t> &nodes,
-                           dlong &Nshared,
-                           memory<parallelNode_t> &sharedNodes);
+  void ConstructSharedNodes(const memory<hlong> haloBaseIds,
+                            dlong &Nshared,
+                            memory<int>&   sharedRemoteRanks,
+                            memory<dlong>& sharedLocalRows,
+                            memory<dlong>& sharedRemoteRows,
+                            memory<hlong>& sharedLocalBaseIds,
+                            memory<hlong>& sharedRemoteBaseIds);
 
-  void LocalSignedSetup(const dlong Nids, memory<parallelNode_t> &nodes);
-  void LocalUnsignedSetup(const dlong Nids, memory<parallelNode_t> &nodes);
-  void LocalHaloSetup(const dlong Nids, memory<parallelNode_t> &nodes);
-
-  ogsExchange_t* AutoSetup(dlong Nshared,
-                           memory<parallelNode_t> &sharedNodes,
+  ogsExchange_t* AutoSetup(const dlong Nshared,
+                           const memory<int>   sharedRemoteRanks,
+                           const memory<dlong> sharedLocalRows,
+                           const memory<dlong> sharedRemoteRows,
+                           const memory<hlong> sharedLocalBaseIds,
+                           const memory<hlong> sharedRemoteBaseIds,
+                           const memory<hlong> haloBaseIds,
                            ogsOperator_t& gatherHalo,
                            comm_t _comm,
                            platform_t &_platform,

--- a/include/ogs/ogsOperator.hpp
+++ b/include/ogs/ogsOperator.hpp
@@ -33,6 +33,11 @@ namespace libp {
 
 namespace ogs {
 
+//NC: Hard code these for now. Should be sufficient for GPU devices, but needs attention for CPU
+constexpr int blockSize = 256;
+constexpr int gatherNodesPerBlock = 512; //should be a multiple of blockSize for good unrolling
+
+
 // The Z operator class is essentially a sparse CSR matrix,
 // with no vals stored. By construction, the sparse
 // matrix will have at most 1 non-zero per column.
@@ -66,12 +71,17 @@ public:
   Kind kind;
 
   ogsOperator_t()=default;
-  ogsOperator_t(platform_t& _platform)
-   : platform(_platform) {};
+  ogsOperator_t(platform_t &platform_,
+                Kind kind_,
+                const dlong NrowsN_,
+                const dlong NrowsT_,
+                const dlong Ncols_,
+                const dlong Nids,
+                memory<hlong> baseIds,
+                memory<dlong> rows,
+                memory<dlong> cols);
 
   void Free();
-
-  void setupRowBlocks();
 
   //Apply Z operator
   template<template<typename> class U,
@@ -117,10 +127,6 @@ private:
             typename T>
   void GatherScatter(U<T> v, const int K,
                      const Transpose trans);
-
-  //NC: Hard code these for now. Should be sufficient for GPU devices, but needs attention for CPU
-  static constexpr int blockSize = 256;
-  static constexpr int gatherNodesPerBlock = 512; //should be a multiple of blockSize for good unrolling
 
   //4 types - Float, Double, Int32, Int64
   //4 ops - Add, Mul, Max, Min

--- a/include/ogs/ogsUtils.hpp
+++ b/include/ogs/ogsUtils.hpp
@@ -33,19 +33,6 @@ namespace libp {
 
 namespace ogs {
 
-struct parallelNode_t{
-
-  dlong localId;    // local node id
-  hlong baseId;     // original global index
-
-  dlong newId;         // new global id
-  int sign;
-
-  int rank; //original rank
-  int destRank; //destination rank
-
-};
-
 template<typename T>
 struct ogsType {
   static constexpr Type get();
@@ -63,22 +50,6 @@ template<> struct ogsType<int> {
 template<> struct ogsType<long long int> {
   static constexpr Type get() { return Int64; }
 };
-
-//permute an array A, according to the ordering returned by P
-// i.e. for all n, A[P(n)] <- A[n]
-template<typename T, class Order>
-void permute(const dlong N, memory<T> A, Order P) {
-
-  for(dlong n=0;n<N;++n) {
-    //get what index A[n] should move to
-    dlong pn = P(A[n]);
-    while (pn!=n) {
-      //swap
-      std::swap(A[n], A[pn]);
-      pn = P(A[n]);
-    }
-  }
-}
 
 } //namespace ogs
 

--- a/include/primitives.hpp
+++ b/include/primitives.hpp
@@ -1,0 +1,460 @@
+/*
+
+The MIT License (MIT)
+
+Copyright (c) 2017-2023 Tim Warburton, Noel Chalmers, Jesse Chan, Ali Karakus
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+*/
+
+#ifndef PRIMITIVES_HPP
+#define PRIMITIVES_HPP
+
+#include "core.hpp"
+#include "memory.hpp"
+
+namespace libp {
+
+namespace prim {
+
+/// min: Parallel primitive returning minimum value in input array
+///
+/// Equivalent to the following code
+/// min_v = std::numeric_limits<T>::max();
+/// for(std::size_t i = 0; i < N; ++i) {
+///   min_v = std::min(min_v, v[n]);
+/// }
+/// return min_v;
+///
+/// Example
+/// memory<int> input; // e.g., [1, 2, 3, 4, 3, 3, 7, 3]
+///
+/// n = prim::min(8, input);
+/// // n: 1
+template<typename T>
+T min(const dlong N, const memory<T> v);
+
+
+/// max: Parallel primitive returning maximum value in input array
+///
+/// Equivalent to the following code
+/// max_v = -std::numeric_limits<T>::max();
+/// for(std::size_t i = 0; i < N; ++i) {
+///   max_v = std::max(max_v, v[n]);
+/// }
+/// return max_v;
+///
+/// Example
+/// memory<int> input; // e.g., [1, 2, 3, 4, 3, 3, 7, 3]
+///
+/// n = prim::max(8, input);
+/// // n: 7
+template<typename T>
+T max(const dlong N, const memory<T> v);
+
+
+/// sum: Parallel primitive returning sum of all values in input array
+///
+/// Equivalent to the following code
+/// sum_v = 0;
+/// for(std::size_t i = 0; i < N; ++i) {
+///   sum_v += v[n];
+/// }
+/// return sum_v;
+///
+/// Example
+/// memory<int> input; // e.g., [1, 2, 3, 4, 3, 3, 7, 3]
+///
+/// n = prim::sum(8, input);
+/// // n: 26
+template<typename T>
+T sum(const dlong N, const memory<T> v);
+
+
+/// abs: Parallel primitive returning absolute value of an input array
+///
+/// Equivalent to the following code
+/// for(std::size_t i = 0; i < N; ++i) {
+///   absv[n] = std::abs(v[n]);
+/// }
+///
+/// Example
+/// memory<int> input; // e.g., [-1, 2, -3, -4, 3, -3, -7, -3]
+/// memory<int> output; // empty array of 8 elements
+///
+/// n = prim::abs(8, input, output);
+/// // output: [1, 2, 3, 4, 3, 3, 7, 3]
+template<typename T>
+void abs(const dlong N, const memory<T> v, memory<T> absv);
+
+
+/// set: Parallel primitive assigning an input array to a value
+///
+/// Equivalent to the following code
+/// for(std::size_t i = 0; i < N; ++i) {
+///   v[n] = val;
+/// }
+///
+/// Example
+/// memory<int> output; // empty array of 8 elements
+///
+/// n = prim::set(8, 2, output);
+/// // output: [2, 2, 2, 2, 2, 2, 2, 2]
+template<typename T>
+void set(const dlong N, const T val, memory<T> v);
+
+
+/// range: Parallel primitive creating an ordered range in an
+/// output array
+///
+/// Equivalent to the following code
+/// for(std::size_t i = 0; i < N; ++i) {
+///   v[n] = start + step * i;
+/// }
+///
+/// Example
+/// memory<int> output; // empty array of 8 elements
+///
+/// n = prim::range(8, 2, 4 output);
+/// // output: [2, 6, 10, 14, 18, 22, 26, 30]
+template<typename T>
+void range(const dlong N, const T start, const T step, memory<T> v);
+
+
+/// count: Parallel primitive for counting occurances of given value in
+/// input array
+///
+/// Equivalent to the following code
+/// count = 0;
+/// for(std::size_t i = 0; i < N; ++i) {
+///   count += (input[i] == value) ? 1 : 0;
+/// }
+/// return count;
+///
+/// Example
+/// memory<int> input; // e.g., [1, 2, 1, 4, 1, 1, 7, 1]
+///
+/// n = prim::count(8, input, 1);
+/// // n: 5
+template<typename T>
+dlong count(const dlong N, const memory<T> v, const T& value);
+
+
+/// exclusiveScan: Parallel primitive for in-place exclusive prefix sum.
+///
+/// Equivalent to the following code
+/// T sum = 0;
+/// for(std::size_t i = 0; i < N; ++i) {
+///   T v = v[i];
+///   v[i] = sum;
+///   sum += v;
+/// }
+///
+/// Example
+/// memory<int> input; // e.g., [1, 2, 3, 4, 5, 6, 7, 8]
+///
+/// prim::exclusiveScan(8, input);
+/// // input: [0, 1, 3, 6, 10, 15, 21, 28]
+template<typename T>
+void exclusiveScan(const dlong N, memory<T> v);
+
+
+/// exclusiveScan: Parallel primitive for exclusive prefix sum.
+///
+/// Equivalent to the following code
+/// T sum = 0;
+/// for(std::size_t i = 0; i < N; ++i) {
+///   output[i] = sum;
+///   sum += input[i];
+/// }
+///
+/// Example
+/// memory<int> input; // e.g., [1, 2, 3, 4, 5, 6, 7, 8]
+/// memory<int> output; // empty array of 8 elements
+///
+/// prim::exclusiveScan(8, input, output);
+/// // output: [0, 1, 3, 6, 10, 15, 21, 28]
+template<typename T>
+void exclusiveScan(const dlong N, const memory<T> v, memory<T> w);
+
+
+/// inclusiveScan: Parallel primitive for in-place inclusive prefix sum.
+///
+/// Equivalent to the following code
+/// T sum = 0;
+/// for(std::size_t i = 0; i < N; ++i) {
+///   sum += v[i];
+///   v[i] = sum;
+/// }
+///
+/// Example
+/// memory<int> input; // e.g., [1, 2, 3, 4, 5, 6, 7, 8]
+///
+/// prim::inclusiveScan(8, input);
+/// // input: [1, 3, 6, 10, 15, 21, 28, 36]
+template<typename T>
+void inclusiveScan(const dlong N, memory<T> v);
+
+
+/// inclusiveScan: Parallel primitive for inclusive prefix sum.
+///
+/// Equivalent to the following code
+/// T sum = 0;
+/// for(std::size_t i = 0; i < N; ++i) {
+///   sum += input[i];
+///   output[i] = sum;
+/// }
+///
+/// Example
+/// memory<int> input; // e.g., [1, 2, 3, 4, 5, 6, 7, 8]
+/// memory<int> output; // empty array of 8 elements
+///
+/// prim::inclusiveScan(8, input, output);
+/// // output: [1, 3, 6, 10, 15, 21, 28, 36]
+template<typename T>
+void inclusiveScan(const dlong N, const memory<T> v, memory<T> w);
+
+
+/// sort: Parallel increasing sort. Sorts an input array based on
+/// the < comparison
+///
+/// Example
+/// memory<double> input; // e.g., [0.6, 0.3, 0.65, 0.4, 0.2, 0.08, 1, 0.7]
+///
+/// prim::sort(8, input);
+/// // input: [0.08, 0.2, 0.3, 0.4, 0.6, 0.65, 0.7, 1]
+template<typename T>
+void sort(const dlong N, memory<T> v);
+
+
+/// sort: Parallel increasing sort with ids. Sorts an input array based on
+/// the < comparison and returns an array of the original locations
+/// for each entry.
+///
+/// Example
+/// memory<double> input; // e.g., [0.6, 0.3, 0.65, 0.4, 0.2, 0.08, 1, 0.7]
+/// memory<int> ids; // empty array of 8 elements
+///
+/// prim::sort(8, input, ids);
+/// // input: [0.08, 0.2, 0.3, 0.4, 0.6, 0.65, 0.7, 1]
+/// // ids: [5, 4, 1, 3, 0, 2, 7, 6]
+template<typename T>
+void sort(const dlong N, memory<T> v, memory<dlong> sortIds);
+
+
+/// stableSort: Parallel stable increasing sort. Sorts an input array based on
+/// the < comparison, preserving the relative order of equal elements.
+///
+/// Example
+/// memory<double> input; // e.g., [0.6, 0.3, 0.65, 0.4, 0.2, 0.08, 1, 0.7]
+///
+/// prim::sort(8, input);
+/// // input: [0.08, 0.2, 0.3, 0.4, 0.6, 0.65, 0.7, 1]
+template<typename T>
+void stableSort(const dlong N, memory<T> v);
+
+
+/// stableSort: Parallel stable increasing sort with ids. Sorts an input array based on
+/// the < comparison and returns an array of the original locations
+/// for each entry. Preserves the relative order of equal elements.
+///
+/// Example
+/// memory<double> input; // e.g., [0.6, 0.3, 0.65, 0.4, 0.2, 0.08, 1, 0.7]
+/// memory<int> ids; // empty array of 8 elements
+///
+/// prim::sort(8, input, ids);
+/// // input: [0.08, 0.2, 0.3, 0.4, 0.6, 0.65, 0.7, 1]
+/// // ids: [5, 4, 1, 3, 0, 2, 7, 6]
+template<typename T>
+void stableSort(const dlong N, memory<T> v, memory<dlong> sortIds);
+
+
+/// transformGather: Parallel primitive for indirectly reading
+/// an input array
+///
+/// Equivalent to the following code
+/// for(std::size_t i = 0; i < N; ++i) {
+///   output[n] = input[ids[n]];
+/// }
+///
+/// Example
+/// memory<int> input; // e.g., [1, 2, 3, 4, 5, 6, 7, 8]
+/// memory<int> ids;   // e.g., [2, 2, 7, 6, 1, 3, 3, 3]
+/// memory<int> output; // empty array of 8 elements
+///
+/// prim::transformGather(8, ids, input, output);
+/// // output: [3, 3, 8, 7, 2, 4, 4, 4]
+template<typename T>
+void transformGather(const dlong N,
+                     const memory<dlong> ids,
+                     const memory<T> v,
+                           memory<T> w);
+
+
+/// transformScatter: Parallel primitive for indirectly writing to
+/// an output array. Note that the array of ids to be written
+/// must not contain duplicates or data races may occur.
+///
+/// Equivalent to the following code
+/// for(std::size_t i = 0; i < N; ++i) {
+///   output[ids[n]] = input[n];
+/// }
+///
+/// Example
+/// memory<int> input; // e.g., [1, 2, 3, 4, 5, 6, 7, 8]
+/// memory<int> ids;   // e.g., [1, 0, 3, 2, 5, 4, 7, 6]
+/// memory<int> output; // empty array of 8 elements
+///
+/// prim::transformScatter(8, ids, input, output);
+/// // output: [2, 1, 4, 3, 6, 5, 8, 7]
+template<typename T>
+void transformScatter(const dlong N,
+                      const memory<dlong> ids,
+                      const memory<T> v,
+                            memory<T> w);
+
+
+/// adjacentDifference: Parallel primitive for applying a difference operation across pairs of
+/// consecutive elements. Writes the output to the position of the left item.
+///
+/// Copies the first item to the output then performs the difference operator with each pair
+/// of neighboring elements and writes its result to the location of the second element.
+/// Equivalent to the following code
+/// output[0] = input[0];
+/// for(std::size_t i = 1; i < N; ++i) {
+///     output[i] = input[i] - input[i - 1];
+/// }
+///
+/// Example
+/// memory<int> input; // e.g., [8, 7, 6, 5, 4, 3, 2, 1]
+/// memory<int> output; // empty array of 8 elements
+///
+/// prim::adjacentDifference(8, input, output);
+/// // output: [8, -1, -1, -1, -1, -1, -1, -1]
+template<typename T>
+void adjacentDifference(const dlong N, const memory<T> v, memory<T> diff);
+
+
+/// adjacentDifferenceFlag: Parallel primitive for flagging differences across pairs of
+/// consecutive elements. Writes the output to the position of the left item.
+///
+/// Writes a 1 to the first output location then performs the difference operator with each pair
+/// of neighboring elements and writes a 1 to the location of the second element if a non-zero differnce exists.
+/// Equivalent to the following code
+/// output[0] = 1;
+/// for(std::size_t i = 1; i < N; ++i) {
+///     output[i] = (input[i] - input[i - 1]) ? 1 : 0;
+/// }
+///
+/// Example
+/// memory<int> input; // e.g., [8, 7, 7, 5, 5, 3, 3, 3]
+/// memory<int> output; // empty array of 8 elements
+///
+/// prim::adjacentDifferenceFlag(8, input, output);
+/// // output: [1, 1, 0, 1, 0, 1, 0, 0]
+template<typename T>
+void adjacentDifferenceFlag(const dlong N, const memory<T> v, memory<dlong> flag);
+
+
+/// select: Parallel select primitive. Performs a selection of entries of an input
+/// array based on an input flag. The output array must be large enough to hold all
+/// locations.
+///
+/// Example
+/// memory<int> input; // e.g., [1, 2, 2, 1, 3, 2, 4, 4]
+/// memory<int> output(prim::count(8, input, 2)); // empty array of 3 elements
+///
+/// prim::select(8, input, 2, output);
+/// // output: [1, 2, 5]
+template<typename T>
+void select(const dlong N, const memory<T> v, const T& val, memory<dlong> ids);
+
+
+/// unique: Parallel unique primitive. From given input range, eliminates
+/// all but the first element from every consecutive group of equivalent elements
+/// and copies them into output.
+///
+/// Example
+/// memory<int> input; // e.g., [1, 4, 2, 4, 4, 7, 7, 7]
+/// memory<int> output; // uninitialized array
+///
+/// prim::select(8, input, Nunique, output);
+/// // Nunique: 5
+/// // output: [1, 4, 2, 4, 7]
+template<typename T>
+void unique(const dlong N,
+            const memory<T> v,
+                  dlong& Nunique,
+                  memory<T>& v_unique);
+
+
+/// runLengthEncode: Parallel run-length encoding. Encodes the size of groups of
+/// consequtive values of the input array.
+///
+/// Example
+/// memory<int> input; // e.g., [1, 1, 1, 2, 10, 10, 10, 88]
+/// memory<int> output; // uninitialized array
+///
+/// prim::runLengthEncode(8, input, Ngroups, output);
+/// // Ngroups: 4
+/// // output: [0, 3, 4, 7, 8]
+template<typename T>
+void runLengthEncode(const dlong N,
+                     const memory<T> v,
+                     dlong& Ngroups,
+                     memory<dlong>& offset);
+
+
+/// runLengthEncodeConsecutive: Parallel run-length encoding.
+/// Encodes the size of groups of cconsequtive values of the input array,
+/// assuming precisely Ngroups of values exist from the range [0, Ngroups-1]
+/// in order
+///
+/// Example
+/// memory<int> input; // e.g., [1, 1, 1, 2, 4, 5, 5, 5]
+/// memory<int> output; // empty array of 9 elements
+///
+/// prim::runLengthEncodeConsecutive(8, input, 6, output);
+/// // output: [0, 0, 3, 4, 4, 5, 8]
+template<typename T>
+void runLengthEncodeConsecutive(const dlong N,
+                                const memory<T> v,
+                                dlong Ngroups,
+                                memory<dlong> offset);
+
+
+/// random: Parallel random number generation.
+/// Creates an array of randomly generated numbers. The generation is
+/// the same regardless of whether execution was parallel or serial.
+/// For floating-point types, the randomly generated values will be
+/// between 0. and 1., while for integer types the generated values
+/// will be between 0 and the maximum signed value of the type.
+template <typename T>
+void random(const dlong N, memory<T> v);
+
+
+/// seedRNG: Seed the random number generator used in prim::random
+void seedRNG(const uint64_t seed);
+
+}
+
+} //namespace libp
+
+#endif

--- a/libs/core/comm.cpp
+++ b/libs/core/comm.cpp
@@ -103,6 +103,10 @@ void comm_t::Waitall(const int count, memory<request_t> &requests) const {
   MPI_Waitall(count, requests.ptr(), MPI_STATUSES_IGNORE);
 }
 
+void comm_t::Waitall(const int count, request_t* requests) const {
+  MPI_Waitall(count, requests, MPI_STATUSES_IGNORE);
+}
+
 void comm_t::Barrier() const {
   MPI_Barrier(comm());
 }

--- a/libs/makefile
+++ b/libs/makefile
@@ -36,6 +36,7 @@ endif
 LIBCORE_DIR=${HIPBONE_LIBS_DIR}/core
 LIBMESH_DIR=${HIPBONE_LIBS_DIR}/mesh
 LIBOGS_DIR=${HIPBONE_LIBS_DIR}/ogs
+LIBPRIM_DIR=${HIPBONE_LIBS_DIR}/primitives
 
 #includes
 INCLUDES=${HIPBONE_INCLUDES}
@@ -44,6 +45,7 @@ INCLUDES=${HIPBONE_INCLUDES}
 LIBCORE_DEFINES=${HIPBONE_DEFINES}
 LIBMESH_DEFINES=${HIPBONE_DEFINES}
 LIBOGS_DEFINES=${HIPBONE_DEFINES}
+LIBPRIM_DEFINES=${HIPBONE_DEFINES}
 
 ifeq (true,${gpu-aware-mpi})
   LIBOGS_DEFINES+= -DGPU_AWARE_MPI
@@ -61,21 +63,25 @@ LIBOGS_DEPS=${LIB_DEPS} \
 LIBCORE_SRC =$(wildcard core/*.cpp)
 LIBMESH_SRC =$(wildcard mesh/*.cpp)
 LIBOGS_SRC =$(wildcard ogs/*.cpp)
+LIBPRIM_SRC =$(wildcard primitives/*.cpp)
 
 LIBCORE_OBJS=$(LIBCORE_SRC:.cpp=.o)
 LIBMESH_OBJS=$(LIBMESH_SRC:.cpp=.o)
 LIBOGS_OBJS=$(LIBOGS_SRC:.cpp=.o)
+LIBPRIM_OBJS=$(LIBPRIM_SRC:.cpp=.o)
 
 #install prefix
 PREFIX ?= ${HIPBONE_DIR}/install
 
-.PHONY: all core mesh ogs \
+.PHONY: all core prim mesh ogs \
         clean realclean silentUpdate-core  \
-        silentUpdate-ogs silentUpdate-mesh
+        silentUpdate-ogs silentUpdate-mesh \
+        silentUpdate-prim
 
-all: core mesh ogs
+all: core prim mesh ogs
 
 core: libcore.a silentUpdate-core
+prim: libprim.a silentUpdate-prim
 mesh: libmesh.a silentUpdate-mesh
 ogs: libogs.a silentUpdate-ogs
 
@@ -87,7 +93,15 @@ else
 	@ar -cr libcore.a $(LIBCORE_OBJS)
 endif
 
-libogs.a: $(LIBOGS_OBJS) | libcore.a
+libprim.a: $(LIBPRIM_OBJS) | libcore.a
+ifneq (,${verbose})
+	ar -cr libprim.a $(LIBPRIM_OBJS)
+else
+	@printf "%b" "$(LIB_COLOR)Building library $(@F)$(NO_COLOR)\n";
+	@ar -cr libprim.a $(LIBPRIM_OBJS)
+endif
+
+libogs.a: $(LIBOGS_OBJS) | libprim.a
 ifneq (,${verbose})
 	ar -cr libogs.a $(LIBOGS_OBJS)
 else
@@ -104,6 +118,9 @@ else
 endif
 
 silentUpdate-core:
+	@true
+
+silentUpdate-prim:
 	@true
 
 silentUpdate-ogs:
@@ -137,12 +154,20 @@ else
 	@$(HIPBONE_CXX) -o $@ -c $< ${LIBMESH_DEFINES} $(LIB_CXXFLAGS)
 endif
 
-ogs/%.o: ogs/%.cpp $(LIBOGS_DEPS) | libcore.a
+ogs/%.o: ogs/%.cpp $(LIBOGS_DEPS) | libprim.a
 ifneq (,${verbose})
 	$(HIPBONE_CXX) -o $@ -c $< ${LIBOGS_DEFINES} $(LIB_CXXFLAGS)
 else
 	@printf "%b" "$(OBJ_COLOR)Compiling $(@F)$(NO_COLOR)\n";
 	@$(HIPBONE_CXX) -o $@ -c $< ${LIBOGS_DEFINES} $(LIB_CXXFLAGS)
+endif
+
+primitives/%.o: primitives/%.cpp $(LIBOGS_DEPS) | libcore.a
+ifneq (,${verbose})
+	$(HIPBONE_CXX) -o $@ -c $< ${LIBPRIM_DEFINES} $(LIB_CXXFLAGS)
+else
+	@printf "%b" "$(OBJ_COLOR)Compiling $(@F)$(NO_COLOR)\n";
+	@$(HIPBONE_CXX) -o $@ -c $< ${LIBPRIM_DEFINES} $(LIB_CXXFLAGS)
 endif
 
 install:
@@ -154,4 +179,4 @@ install:
 
 #cleanup
 clean:
-	rm -f core/*.o mesh/*.o ogs/*.o *.a
+	rm -f core/*.o primitives/*.o mesh/*.o ogs/*.o *.a

--- a/libs/ogs/ogsAllToAll.cpp
+++ b/libs/ogs/ogsAllToAll.cpp
@@ -27,153 +27,205 @@ SOFTWARE.
 #include "ogs.hpp"
 #include "ogs/ogsUtils.hpp"
 #include "ogs/ogsExchange.hpp"
-
-#ifdef GLIBCXX_PARALLEL
-#include <parallel/algorithm>
-using __gnu_parallel::sort;
-#else
-using std::sort;
-#endif
+#include "primitives.hpp"
 
 namespace libp {
 
 namespace ogs {
 
+static inline
+void scale(const dlong N, const memory<int>& v,  const int val, memory<int>& w) {
+  #pragma omp parallel for
+  for (int n=0;n<N;++n) { w[n] = val*v[n]; }
+}
+
 /**********************************
 * Host exchange
 ***********************************/
 template<typename T>
-inline void ogsAllToAll_t::Start(pinnedMemory<T> &buf, const int k,
-                          const Op op, const Transpose trans){
+inline void ogsAllToAll_t::HostStart(const int k, const Op op, const Transpose trans){
 
   pinnedMemory<T> sendBuf = h_sendspace;
+  pinnedMemory<T> workBuf = h_workspace;
 
-  // extract the send buffer
-  if (trans == NoTrans)
-    extract(NsendN, k, sendIdsN, buf, sendBuf);
-  else
-    extract(NsendT, k, sendIdsT, buf, sendBuf);
+  // Get the exchange data based on the mode
+  data_t& d = data[trans];
 
-  if (trans==NoTrans) {
-    for (int r=0;r<size;++r) {
-      sendCounts[r] = k*mpiSendCountsN[r];
-      recvCounts[r] = k*mpiRecvCountsN[r];
-      sendOffsets[r+1] = k*mpiSendOffsetsN[r+1];
-      recvOffsets[r+1] = k*mpiRecvOffsetsN[r+1];
-    }
-  } else {
-    for (int r=0;r<size;++r) {
-      sendCounts[r] = k*mpiSendCountsT[r];
-      recvCounts[r] = k*mpiRecvCountsT[r];
-      sendOffsets[r+1] = k*mpiSendOffsetsT[r+1];
-      recvOffsets[r+1] = k*mpiRecvOffsetsT[r+1];
-    }
-  }
+  // extract the send buffer and set send sizes
+  extract(d.Nsend, k, d.sendIds, sendBuf, workBuf);
+  scale(size,   d.sendCounts,  k, sendCounts);
+  scale(size,   d.recvCounts,  k, recvCounts);
+  scale(size+1, d.sendOffsets, k, sendOffsets);
+  scale(size+1, d.recvOffsets, k, recvOffsets);
 
   // collect everything needed with single MPI all to all
-  comm.Ialltoallv(sendBuf,     sendCounts, sendOffsets,
-                  buf+Nhalo*k, recvCounts, recvOffsets,
+  comm.Ialltoallv(workBuf,            sendCounts, sendOffsets,
+                  sendBuf+d.NrowsP*k, recvCounts, recvOffsets,
                   request);
 }
 
 template<typename T>
-inline void ogsAllToAll_t::Finish(pinnedMemory<T> &buf, const int k,
-                           const Op op, const Transpose trans){
+inline void ogsAllToAll_t::HostFinish(const int k, const Op op, const Transpose trans){
 
+  pinnedMemory<T> sendBuf = h_sendspace;
+  pinnedMemory<T> recvBuf = h_recvspace;
   comm.Wait(request);
 
-  //if we recvieved anything via MPI, gather the recv buffer and scatter
-  // it back to to original vector
-  dlong Nrecv = recvOffsets[size];
-  if (Nrecv) {
-    // gather the recieved nodes
-    postmpi.Gather(buf, buf, k, op, trans);
-  }
+  // Get the exchange data based on the mode
+  data_t& d = data[trans];
+
+  // gather the recieved nodes
+  d.postmpi.Gather(recvBuf, sendBuf, k, op, Sym);
 }
 
-void ogsAllToAll_t::Start(pinnedMemory<float> &buf, const int k, const Op op, const Transpose trans) { Start<float>(buf, k, op, trans); }
-void ogsAllToAll_t::Start(pinnedMemory<double> &buf, const int k, const Op op, const Transpose trans) { Start<double>(buf, k, op, trans); }
-void ogsAllToAll_t::Start(pinnedMemory<int> &buf, const int k, const Op op, const Transpose trans) { Start<int>(buf, k, op, trans); }
-void ogsAllToAll_t::Start(pinnedMemory<long long int> &buf, const int k, const Op op, const Transpose trans) { Start<long long int>(buf, k, op, trans); }
-void ogsAllToAll_t::Finish(pinnedMemory<float> &buf, const int k, const Op op, const Transpose trans) { Finish<float>(buf, k, op, trans); }
-void ogsAllToAll_t::Finish(pinnedMemory<double> &buf, const int k, const Op op, const Transpose trans) { Finish<double>(buf, k, op, trans); }
-void ogsAllToAll_t::Finish(pinnedMemory<int> &buf, const int k, const Op op, const Transpose trans) { Finish<int>(buf, k, op, trans); }
-void ogsAllToAll_t::Finish(pinnedMemory<long long int> &buf, const int k, const Op op, const Transpose trans) { Finish<long long int>(buf, k, op, trans); }
+void ogsAllToAll_t::HostStart(const Type type, const int k, const Op op, const Transpose trans) {
+  switch (type) {
+    case Int32:  HostStart<int>(k, op, trans); break;
+    case Int64:  HostStart<long long int>(k, op, trans); break;
+    case Float:  HostStart<float>(k, op, trans); break;
+    case Double: HostStart<double>(k, op, trans); break;
+  }
+}
+void ogsAllToAll_t::HostFinish(const Type type, const int k, const Op op, const Transpose trans) {
+  switch (type) {
+    case Int32:  HostFinish<int>(k, op, trans); break;
+    case Int64:  HostFinish<long long int>(k, op, trans); break;
+    case Float:  HostFinish<float>(k, op, trans); break;
+    case Double: HostFinish<double>(k, op, trans); break;
+  }
+}
 
 /**********************************
 * GPU-aware exchange
 ***********************************/
 template<typename T>
-void ogsAllToAll_t::Start(deviceMemory<T> &o_buf,
-                          const int k,
-                          const Op op,
-                          const Transpose trans){
+void ogsAllToAll_t::DeviceStart(const int k, const Op op, const Transpose trans){
 
-  const dlong Nsend = (trans == NoTrans) ? NsendN : NsendT;
+  deviceMemory<T> o_sendBuf = o_sendspace;
+  deviceMemory<T> o_workBuf = o_workspace;
 
-  if (Nsend) {
-    deviceMemory<T> o_sendBuf = o_sendspace;
+  // Get the exchange data based on the mode
+  data_t& d = data[trans];
 
-    // assemble the send buffer on device
-    if (trans == NoTrans) {
-      extractKernel[ogsType<T>::get()](NsendN, k, o_sendIdsN, o_buf, o_sendBuf);
-    } else {
-      extractKernel[ogsType<T>::get()](NsendT, k, o_sendIdsT, o_buf, o_sendBuf);
-    }
-    //wait for kernel to finish on default stream
+  // assemble the send buffer on device
+  extractKernel[ogsType<T>::get()](d.Nsend, k, d.o_sendIds, o_sendBuf, o_workBuf);
+
+  // set send sizes
+  scale(size,   d.sendCounts,  k, sendCounts);
+  scale(size,   d.recvCounts,  k, recvCounts);
+  scale(size+1, d.sendOffsets, k, sendOffsets);
+  scale(size+1, d.recvOffsets, k, recvOffsets);
+
+  //wait for kernel to finish on default stream
+  if (d.Nsend) {
     device_t &device = platform.device;
     device.finish();
   }
 }
 
 template<typename T>
-void ogsAllToAll_t::Finish(deviceMemory<T> &o_buf,
-                           const int k,
-                           const Op op,
-                           const Transpose trans){
+void ogsAllToAll_t::DeviceFinish(const int k, const Op op, const Transpose trans){
 
   deviceMemory<T> o_sendBuf = o_sendspace;
+  deviceMemory<T> o_workBuf = o_workspace;
+  deviceMemory<T> o_recvBuf = o_recvspace;
 
-  if (trans==NoTrans) {
-    for (int r=0;r<size;++r) {
-      sendCounts[r] = k*mpiSendCountsN[r];
-      recvCounts[r] = k*mpiRecvCountsN[r];
-      sendOffsets[r+1] = k*mpiSendOffsetsN[r+1];
-      recvOffsets[r+1] = k*mpiRecvOffsetsN[r+1];
-    }
-  } else {
-    for (int r=0;r<size;++r) {
-      sendCounts[r] = k*mpiSendCountsT[r];
-      recvCounts[r] = k*mpiRecvCountsT[r];
-      sendOffsets[r+1] = k*mpiSendOffsetsT[r+1];
-      recvOffsets[r+1] = k*mpiRecvOffsetsT[r+1];
-    }
-  }
+  // Get the exchange data based on the mode
+  data_t& d = data[trans];
 
   // collect everything needed with single MPI all to all
-  comm.Alltoallv(o_sendBuf,     sendCounts, sendOffsets,
-                 o_buf+Nhalo*k, recvCounts, recvOffsets);
+  comm.Alltoallv(o_workBuf,            sendCounts, sendOffsets,
+                 o_sendBuf+d.NrowsP*k, recvCounts, recvOffsets);
 
-  //if we recvieved anything via MPI, gather the recv buffer and scatter
-  // it back to to original vector
-  dlong Nrecv = recvOffsets[size];
-  if (Nrecv) {
-    // gather the recieved nodes on device
-    postmpi.Gather(o_buf, o_buf, k, op, trans);
+  // gather the recieved nodes on device
+  d.postmpi.Gather(o_recvBuf, o_sendBuf, k, op, Sym);
+}
+
+void ogsAllToAll_t::DeviceStart(const Type type, const int k, const Op op, const Transpose trans) {
+  switch (type) {
+    case Int32:  DeviceStart<int>(k, op, trans); break;
+    case Int64:  DeviceStart<long long int>(k, op, trans); break;
+    case Float:  DeviceStart<float>(k, op, trans); break;
+    case Double: DeviceStart<double>(k, op, trans); break;
+  }
+}
+void ogsAllToAll_t::DeviceFinish(const Type type, const int k, const Op op, const Transpose trans) {
+  switch (type) {
+    case Int32:  DeviceFinish<int>(k, op, trans); break;
+    case Int64:  DeviceFinish<long long int>(k, op, trans); break;
+    case Float:  DeviceFinish<float>(k, op, trans); break;
+    case Double: DeviceFinish<double>(k, op, trans); break;
   }
 }
 
-void ogsAllToAll_t::Start(deviceMemory<float> &buf, const int k, const Op op, const Transpose trans) { Start<float>(buf, k, op, trans); }
-void ogsAllToAll_t::Start(deviceMemory<double> &buf, const int k, const Op op, const Transpose trans) { Start<double>(buf, k, op, trans); }
-void ogsAllToAll_t::Start(deviceMemory<int> &buf, const int k, const Op op, const Transpose trans) { Start<int>(buf, k, op, trans); }
-void ogsAllToAll_t::Start(deviceMemory<long long int> &buf, const int k, const Op op, const Transpose trans) { Start<long long int>(buf, k, op, trans); }
-void ogsAllToAll_t::Finish(deviceMemory<float> &buf, const int k, const Op op, const Transpose trans) { Finish<float>(buf, k, op, trans); }
-void ogsAllToAll_t::Finish(deviceMemory<double> &buf, const int k, const Op op, const Transpose trans) { Finish<double>(buf, k, op, trans); }
-void ogsAllToAll_t::Finish(deviceMemory<int> &buf, const int k, const Op op, const Transpose trans) { Finish<int>(buf, k, op, trans); }
-void ogsAllToAll_t::Finish(deviceMemory<long long int> &buf, const int k, const Op op, const Transpose trans) { Finish<long long int>(buf, k, op, trans); }
 
-ogsAllToAll_t::ogsAllToAll_t(dlong Nshared,
-                             memory<parallelNode_t> &sharedNodes,
+void ogsAllToAll_t::data_t::setupExchange(const dlong Nsend_,
+                                          const dlong NrowsP_,
+                                          const dlong Nrows_,
+                                          const memory<int>   destRanks,
+                                          const memory<dlong> localRows,
+                                          const memory<dlong> remoteRows,
+                                          comm_t comm,
+                                          platform_t& platform) {
+
+  int size = comm.size();
+
+  Nsend = Nsend_;
+  NrowsP = NrowsP_;
+  Nrows = Nrows_;
+
+  sendCounts.malloc(size);
+  recvCounts.malloc(size);
+  sendOffsets.malloc(size+1);
+  recvOffsets.malloc(size+1);
+
+  /*Get length and offsets of groups of destinations*/
+  prim::runLengthEncodeConsecutive(Nsend, destRanks, size, sendOffsets);
+  prim::adjacentDifference(size, sendOffsets+1, sendCounts);
+
+  comm.Alltoall(sendCounts, recvCounts);
+  recvOffsets[0] = 0;
+  prim::inclusiveScan(size, recvCounts, recvOffsets+1);
+  dlong Nrecv = recvOffsets[size]; //total ids to recv
+
+  sendIds.malloc(Nsend);
+  sendIds.copyFrom(localRows);
+  o_sendIds = platform.malloc(sendIds);
+
+  //send the node lists so we know what we'll receive and in what order
+  Ncols = NrowsP + Nrecv;
+  memory<dlong> rows(Ncols);
+  memory<dlong> cols(Ncols);
+
+  prim::range(NrowsP, 0, 1, rows);
+
+  //Send list of rows to each rank
+  comm.Alltoallv(remoteRows,  sendCounts, sendOffsets,
+                 rows+NrowsP, recvCounts, recvOffsets);
+
+  /*Sort groups by their row*/
+  prim::stableSort(Ncols, rows, cols);
+
+  /*Build the gather op to assemble the recieved data from MPI*/
+  postmpi = ogsOperator_t(platform,
+                          Unsigned,
+                          Nrows,
+                          Nrows,
+                          Ncols,
+                          Ncols,
+                          memory<hlong>(),
+                          rows,
+                          cols);
+}
+
+
+ogsAllToAll_t::ogsAllToAll_t(Kind kind,
+                             const dlong Nshared,
+                             const memory<int>   sharedRanks,
+                             const memory<dlong> sharedLocalRows,
+                             const memory<dlong> sharedRemoteRows,
+                             const memory<hlong> sharedLocalBaseIds,
+                             const memory<hlong> sharedRemoteBaseIds,
                              ogsOperator_t& gatherHalo,
                              stream_t _dataStream,
                              comm_t _comm,
@@ -183,173 +235,131 @@ ogsAllToAll_t::ogsAllToAll_t(dlong Nshared,
   Nhalo  = gatherHalo.NrowsT;
   NhaloP = gatherHalo.NrowsN;
 
-  // sort the list by rank to the order where they will be sent by MPI_Allgatherv
-  sort(sharedNodes.ptr(), sharedNodes.ptr()+Nshared,
-       [](const parallelNode_t& a, const parallelNode_t& b) {
-         if(a.rank < b.rank) return true; //group by rank
-         if(a.rank > b.rank) return false;
+  memory<int>   destRanks(Nshared);
+  memory<dlong> destRankSortIds(Nshared);
+  destRanks.copyFrom(sharedRanks);
 
-         return a.newId < b.newId; //then order by the localId relative to this rank
-       });
+  /*Sort list of shared nodes by rank to get the ordering for MPI Alltoallv*/
+  prim::stableSort(Nshared, destRanks, destRankSortIds);
 
-  //make mpi allgatherv counts and offsets
-  mpiSendCountsT.calloc(size);
-  mpiSendCountsN.calloc(size);
-  mpiRecvCountsT.malloc(size);
-  mpiRecvCountsN.malloc(size);
-  mpiSendOffsetsT.malloc(size+1);
-  mpiSendOffsetsN.malloc(size+1);
-  mpiRecvOffsetsN.malloc(size+1);
-  mpiRecvOffsetsT.malloc(size+1);
+  memory<dlong> localRows(Nshared);
+  prim::transformGather(Nshared, destRankSortIds, sharedLocalRows, localRows);
 
-  for (dlong n=0;n<Nshared;n++) { //loop through nodes we need to send
-    const int r = sharedNodes[n].rank;
-    if (sharedNodes[n].sign>0) mpiSendCountsN[r]++;
-    mpiSendCountsT[r]++;
-  }
+  memory<dlong> remoteRows(Nshared);
+  prim::transformGather(Nshared, destRankSortIds, sharedRemoteRows, remoteRows);
 
-  //shared counts
-  comm.Alltoall(mpiSendCountsT, mpiRecvCountsT);
-  comm.Alltoall(mpiSendCountsN, mpiRecvCountsN);
+  // Sym     mode - Send everything, gather to all Nhalo nodes
+  // NoTrans mode - Only send positive baseIds, gather to all Nhalo nodes
+  // Trans   mode - Only send to remote positive baseIds, gather to positive NhaloP nodes
 
-  //cumulative sum
-  mpiSendOffsetsN[0] = 0;
-  mpiSendOffsetsT[0] = 0;
-  mpiRecvOffsetsN[0] = 0;
-  mpiRecvOffsetsT[0] = 0;
-  for (int r=0;r<size;r++) {
-    mpiSendOffsetsN[r+1] = mpiSendOffsetsN[r]+mpiSendCountsN[r];
-    mpiSendOffsetsT[r+1] = mpiSendOffsetsT[r]+mpiSendCountsT[r];
-    mpiRecvOffsetsN[r+1] = mpiRecvOffsetsN[r]+mpiRecvCountsN[r];
-    mpiRecvOffsetsT[r+1] = mpiRecvOffsetsT[r]+mpiRecvCountsT[r];
-  }
+  /*Build the symmetric exchange using all the shared data*/
+  dlong NsendS = Nshared;
+  data[Sym].setupExchange(NsendS,
+                          Nhalo,
+                          Nhalo,
+                          destRanks,
+                          localRows,
+                          remoteRows,
+                          comm,
+                          platform);
 
-  //make ops for scattering halo nodes before sending
-  NsendN=mpiSendOffsetsN[size];
-  NsendT=mpiSendOffsetsT[size];
+  if (kind==Signed) {
+    /*Reorder baseId info*/
+    memory<hlong> localBaseIds(Nshared);
+    prim::transformGather(Nshared, destRankSortIds, sharedLocalBaseIds, localBaseIds);
 
-  sendIdsN.malloc(NsendN);
-  sendIdsT.malloc(NsendT);
+    memory<hlong> remoteBaseIds(Nshared);
+    prim::transformGather(Nshared, destRankSortIds, sharedRemoteBaseIds, remoteBaseIds);
 
-  NsendN=0; //positive node count
-  NsendT=0; //all node count
+    /*NoTrans: Get locations of shared nodes that have a local positive baseId*/
+    memory<int> noTransFlags(Nshared);
 
-  for (dlong n=0;n<Nshared;n++) { //loop through nodes we need to send
-    dlong id = sharedNodes[n].newId; //coalesced index for this baseId on this rank
-    if (sharedNodes[n].sign==2) {
-      sendIdsN[NsendN++] = id;
+    #pragma omp parallel for
+    for (dlong n=0; n<Nshared;++n) {
+      noTransFlags[n] = (localBaseIds[n]>0) ? 1 : 0;
     }
-    sendIdsT[NsendT++] = id;
-  }
-  o_sendIdsT = platform.malloc(sendIdsT);
-  o_sendIdsN = platform.malloc(sendIdsN);
 
-  //send the node lists so we know what we'll receive
-  dlong Nrecv = mpiRecvOffsetsT[size];
-  memory<parallelNode_t> recvNodes(Nrecv);
+    dlong NsendN = prim::count(Nshared, noTransFlags, 1);
+    memory<dlong> noTransIds(NsendN);
+    prim::select(Nshared, noTransFlags, 1, noTransIds);
 
-  //Send list of nodes to each rank
-  comm.Alltoallv(sharedNodes, mpiSendCountsT, mpiSendOffsetsT,
-                   recvNodes, mpiRecvCountsT, mpiRecvOffsetsT);
+    /*Extract the subset of the shared node list for these nodes*/
+    memory<int> destRanksN(NsendN);
+    prim::transformGather(NsendN, noTransIds, destRanks, destRanksN);
 
-  //make ops for gathering halo nodes after an MPI_Allgatherv
-  postmpi.platform = platform;
-  postmpi.kind = Signed;
+    memory<dlong> localRowsN(NsendN);
+    prim::transformGather(NsendN, noTransIds, localRows, localRowsN);
 
-  postmpi.NrowsN = Nhalo;
-  postmpi.NrowsT = Nhalo;
-  postmpi.rowStartsN.malloc(Nhalo+1);
-  postmpi.rowStartsT.malloc(Nhalo+1);
+    memory<dlong> remoteRowsN(NsendN);
+    prim::transformGather(NsendN, noTransIds, remoteRows, remoteRowsN);
 
-  //make array of counters
-  memory<dlong> haloGatherTCounts(Nhalo);
-  memory<dlong> haloGatherNCounts(Nhalo);
+    /*Build the NoTrans exchange*/
+    data[NoTrans].setupExchange(NsendN,
+                                NhaloP,
+                                Nhalo,
+                                destRanksN,
+                                localRowsN,
+                                remoteRowsN,
+                                comm,
+                                platform);
 
-  //count the data that will already be in h_haloBuf.ptr()
-  for (dlong n=0;n<Nhalo;n++) {
-    haloGatherNCounts[n] = (n<NhaloP) ? 1 : 0;
-    haloGatherTCounts[n] = 1;
-  }
+    /*Trans: Get locations of shared nodes that have a remote positive baseId*/
+    memory<int> transFlags(Nshared);
 
-  for (dlong n=0;n<Nrecv;n++) { //loop through nodes needed for gathering halo nodes
-    dlong id = recvNodes[n].localId; //coalesced index for this baseId on this rank
-    if (recvNodes[n].sign==2) haloGatherNCounts[id]++;  //tally
-    haloGatherTCounts[id]++;  //tally
-  }
-
-  postmpi.rowStartsN[0] = 0;
-  postmpi.rowStartsT[0] = 0;
-  for (dlong i=0;i<Nhalo;i++) {
-    postmpi.rowStartsN[i+1] = postmpi.rowStartsN[i] + haloGatherNCounts[i];
-    postmpi.rowStartsT[i+1] = postmpi.rowStartsT[i] + haloGatherTCounts[i];
-    haloGatherNCounts[i] = 0;
-    haloGatherTCounts[i] = 0;
-  }
-  postmpi.nnzN = postmpi.rowStartsN[Nhalo];
-  postmpi.nnzT = postmpi.rowStartsT[Nhalo];
-  postmpi.colIdsN.malloc(postmpi.nnzN);
-  postmpi.colIdsT.malloc(postmpi.nnzT);
-
-  for (dlong n=0;n<NhaloP;n++) {
-    const dlong soffset = postmpi.rowStartsN[n];
-    const int sindex  = haloGatherNCounts[n];
-    postmpi.colIdsN[soffset+sindex] = n; //record id
-    haloGatherNCounts[n]++;
-  }
-  for (dlong n=0;n<Nhalo;n++) {
-    const dlong soffset = postmpi.rowStartsT[n];
-    const int sindex  = haloGatherTCounts[n];
-    postmpi.colIdsT[soffset+sindex] = n; //record id
-    haloGatherTCounts[n]++;
-  }
-
-  dlong cnt=Nhalo; //positive node count
-  for (dlong n=0;n<Nrecv;n++) { //loop through nodes we need to send
-    dlong id = recvNodes[n].localId; //coalesced index for this baseId on this rank
-    if (recvNodes[n].sign==2) {
-      const dlong soffset = postmpi.rowStartsN[id];
-      const int sindex  = haloGatherNCounts[id];
-      postmpi.colIdsN[soffset+sindex] = cnt++; //record id
-      haloGatherNCounts[id]++;
+    #pragma omp parallel for
+    for (dlong n=0; n<Nshared;++n) {
+      transFlags[n] = (remoteBaseIds[n]>0) ? 1 : 0;
     }
-    const dlong soffset = postmpi.rowStartsT[id];
-    const int sindex  = haloGatherTCounts[id];
-    postmpi.colIdsT[soffset+sindex] = n + Nhalo; //record id
-    haloGatherTCounts[id]++;
+
+    dlong NsendT = prim::count(Nshared, transFlags, 1);
+    memory<dlong> transIds(NsendT);
+    prim::select(Nshared, transFlags,  1, transIds);
+
+    /*Extract the subset of the shared node list for these nodes*/
+    memory<int> destRanksT(NsendT);
+    prim::transformGather(NsendT, transIds, destRanks, destRanksT);
+
+    memory<dlong> localRowsT(NsendT);
+    prim::transformGather(NsendT, transIds, localRows, localRowsT);
+
+    memory<dlong> remoteRowsT(NsendT);
+    prim::transformGather(NsendT, transIds, remoteRows, remoteRowsT);
+
+    /*Build the Trans exchange*/
+    data[Trans].setupExchange(NsendT,
+                              NhaloP,
+                              NhaloP,
+                              destRanksT,
+                              localRowsT,
+                              remoteRowsT,
+                              comm,
+                              platform);
+  } else {
+    data[NoTrans] = data[Sym];
+    data[Trans] = data[Sym];
   }
-
-  postmpi.o_rowStartsN = platform.malloc(postmpi.rowStartsN);
-  postmpi.o_rowStartsT = platform.malloc(postmpi.rowStartsT);
-  postmpi.o_colIdsN = platform.malloc(postmpi.colIdsN);
-  postmpi.o_colIdsT = platform.malloc(postmpi.colIdsT);
-
-  //free up space
-  recvNodes.free();
-  haloGatherNCounts.free();
-  haloGatherTCounts.free();
-
-  postmpi.setupRowBlocks();
 
   sendCounts.malloc(size);
   recvCounts.malloc(size);
   sendOffsets.malloc(size+1);
   recvOffsets.malloc(size+1);
 
-  sendOffsets[0]=0;
-  recvOffsets[0]=0;
-
   //make scratch space
   AllocBuffer(sizeof(dfloat));
 }
 
 void ogsAllToAll_t::AllocBuffer(size_t Nbytes) {
-  if (o_workspace.size() < postmpi.nnzT*Nbytes) {
-    h_workspace = platform.hostMalloc<char>(postmpi.nnzT*Nbytes);
-    o_workspace = platform.malloc<char>(postmpi.nnzT*Nbytes);
+  if (o_sendspace.size() < data[Sym].Ncols*Nbytes) {
+    h_sendspace = platform.hostMalloc<char>(data[Sym].Ncols*Nbytes);
+    o_sendspace = platform.malloc<char>(data[Sym].Ncols*Nbytes);
   }
-  if (o_sendspace.size() < NsendT*Nbytes) {
-    h_sendspace = platform.hostMalloc<char>(NsendT*Nbytes);
-    o_sendspace = platform.malloc<char>(NsendT*Nbytes);
+  if (o_workspace.size() < data[Sym].Nsend*Nbytes) {
+    h_workspace = platform.hostMalloc<char>(data[Sym].Nsend*Nbytes);
+    o_workspace = platform.malloc<char>(data[Sym].Nsend*Nbytes);
+  }
+  if (o_recvspace.size() < data[Sym].Nrows*Nbytes) {
+    h_recvspace = platform.hostMalloc<char>(data[Sym].Nrows*Nbytes);
+    o_recvspace = platform.malloc<char>(data[Sym].Nrows*Nbytes);
   }
 }
 

--- a/libs/ogs/ogsAuto.cpp
+++ b/libs/ogs/ogsAuto.cpp
@@ -42,8 +42,6 @@ static void DeviceExchangeTest(ogsExchange_t* exchange, double time[3]) {
   comm_t& comm = exchange->comm;
   int size = comm.size();
 
-  pinnedMemory<dfloat>   buf = exchange->h_workspace;
-  deviceMemory<dfloat> o_buf = exchange->o_workspace;
 
   device_t &device = exchange->platform.device;
 
@@ -51,21 +49,26 @@ static void DeviceExchangeTest(ogsExchange_t* exchange, double time[3]) {
   for (int n=0;n<Ncold;++n) {
     if (exchange->gpu_aware) {
       /*GPU-aware exchange*/
-      exchange->Start (o_buf, 1, Add, Sym);
-      exchange->Finish(o_buf, 1, Add, Sym);
+      exchange->DeviceStart (Dfloat, 1, Add, Sym);
+      exchange->DeviceFinish(Dfloat, 1, Add, Sym);
     } else {
+      pinnedMemory<dfloat>   sendBuf = exchange->getHostSendBuffer();
+      deviceMemory<dfloat> o_sendBuf = exchange->getDeviceSendBuffer();
       //if not using gpu-aware mpi move the halo buffer to the host
-      o_buf.copyTo(buf, exchange->Nhalo,
-                   0, properties_t("async", true));
+      o_sendBuf.copyTo(sendBuf, exchange->Nhalo,
+                       0, properties_t("async", true));
       device.finish();
 
       /*MPI exchange of host buffer*/
-      exchange->Start (buf, 1, Add, Sym);
-      exchange->Finish(buf, 1, Add, Sym);
+      exchange->HostStart (Dfloat, 1, Add, Sym);
+      exchange->HostFinish(Dfloat, 1, Add, Sym);
+
+      pinnedMemory<dfloat>   recvBuf = exchange->getHostRecvBuffer();
+      deviceMemory<dfloat> o_recvBuf = exchange->getDeviceRecvBuffer();
 
       // copy recv back to device
-      o_buf.copyFrom(buf, exchange->Nhalo,
-                     0, properties_t("async", true));
+      o_recvBuf.copyFrom(recvBuf, exchange->Nhalo,
+                         0, properties_t("async", true));
       device.finish(); //wait for transfer to finish
     }
   }
@@ -75,21 +78,26 @@ static void DeviceExchangeTest(ogsExchange_t* exchange, double time[3]) {
   for (int n=0;n<Nhot;++n) {
     if (exchange->gpu_aware) {
       /*GPU-aware exchange*/
-      exchange->Start (o_buf, 1, Add, Sym);
-      exchange->Finish(o_buf, 1, Add, Sym);
+      exchange->DeviceStart (Dfloat, 1, Add, Sym);
+      exchange->DeviceFinish(Dfloat, 1, Add, Sym);
     } else {
+      pinnedMemory<dfloat>   sendBuf = exchange->getHostSendBuffer();
+      deviceMemory<dfloat> o_sendBuf = exchange->getDeviceSendBuffer();
       //if not using gpu-aware mpi move the halo buffer to the host
-      o_buf.copyTo(buf, exchange->Nhalo,
-                   0, properties_t("async", true));
+      o_sendBuf.copyTo(sendBuf, exchange->Nhalo,
+                       0, properties_t("async", true));
       device.finish();
 
       /*MPI exchange of host buffer*/
-      exchange->Start (buf, 1, Add, Sym);
-      exchange->Finish(buf, 1, Add, Sym);
+      exchange->HostStart (Dfloat, 1, Add, Sym);
+      exchange->HostFinish(Dfloat, 1, Add, Sym);
+
+      pinnedMemory<dfloat>   recvBuf = exchange->getHostRecvBuffer();
+      deviceMemory<dfloat> o_recvBuf = exchange->getDeviceRecvBuffer();
 
       // copy recv back to device
-      o_buf.copyFrom(buf, exchange->Nhalo,
-                     0, properties_t("async", true));
+      o_recvBuf.copyFrom(recvBuf, exchange->Nhalo,
+                         0, properties_t("async", true));
       device.finish(); //wait for transfer to finish
     }
   }
@@ -100,8 +108,8 @@ static void DeviceExchangeTest(ogsExchange_t* exchange, double time[3]) {
   comm.Allreduce(localTime, maxTime, comm_t::Max);
   comm.Allreduce(localTime, minTime, comm_t::Min);
 
-  time[0] = sumTime/size; //avg
-  time[1] = minTime;      //min
+  time[0] = minTime;      //min
+  time[1] = sumTime/size; //avg
   time[2] = maxTime;      //max
 }
 
@@ -113,19 +121,17 @@ static void HostExchangeTest(ogsExchange_t* exchange, double time[3]) {
   comm_t& comm = exchange->comm;
   int size = comm.size();
 
-  pinnedMemory<dfloat> buf = exchange->h_workspace;
-
   //dry run
   for (int n=0;n<Ncold;++n) {
-    exchange->Start (buf, 1, Add, Sym);
-    exchange->Finish(buf, 1, Add, Sym);
+    exchange->HostStart (Dfloat, 1, Add, Sym);
+    exchange->HostFinish(Dfloat, 1, Add, Sym);
   }
 
   //hot runs
   timePoint_t start = Time();
   for (int n=0;n<Nhot;++n) {
-    exchange->Start (buf, 1, Add, Sym);
-    exchange->Finish(buf, 1, Add, Sym);
+    exchange->HostStart (Dfloat, 1, Add, Sym);
+    exchange->HostFinish(Dfloat, 1, Add, Sym);
   }
   timePoint_t end = Time();
 
@@ -134,13 +140,18 @@ static void HostExchangeTest(ogsExchange_t* exchange, double time[3]) {
   comm.Allreduce(localTime, maxTime, comm_t::Max);
   comm.Allreduce(localTime, minTime, comm_t::Min);
 
-  time[0] = sumTime/size; //avg
-  time[1] = minTime;      //min
+  time[0] = minTime;      //min
+  time[1] = sumTime/size; //avg
   time[2] = maxTime;      //max
 }
 
-ogsExchange_t* ogsBase_t::AutoSetup(dlong Nshared,
-                                    memory<parallelNode_t> &sharedNodes,
+ogsExchange_t* ogsBase_t::AutoSetup(const dlong Nshared,
+                                    const memory<int>   sharedRemoteRanks,
+                                    const memory<dlong> sharedLocalRows,
+                                    const memory<dlong> sharedRemoteRows,
+                                    const memory<hlong> sharedLocalBaseIds,
+                                    const memory<hlong> sharedRemoteBaseIds,
+                                    const memory<hlong> haloBaseIds,
                                     ogsOperator_t& _gatherHalo,
                                     comm_t _comm,
                                     platform_t &_platform,
@@ -150,9 +161,19 @@ ogsExchange_t* ogsBase_t::AutoSetup(dlong Nshared,
   rank = comm.rank();
   size = comm.size();
 
-  if (size==1) return new ogsPairwise_t(Nshared, sharedNodes,
-                                        _gatherHalo, dataStream,
-                                        comm, platform);
+  Kind knd = (kind == Unsigned) ? Unsigned : Signed;
+
+  if (size==1) return new ogsPairwise_t(knd,
+                                        Nshared,
+                                        sharedRemoteRanks,
+                                        sharedLocalRows,
+                                        sharedRemoteRows,
+                                        sharedLocalBaseIds,
+                                        sharedRemoteBaseIds,
+                                        _gatherHalo,
+                                        dataStream,
+                                        comm,
+                                        platform);
 
   ogsExchange_t* bestExchange;
   Method method;
@@ -160,10 +181,10 @@ ogsExchange_t* ogsBase_t::AutoSetup(dlong Nshared,
 
 #ifdef GPU_AWARE_MPI
   if (rank==0 && verbose)
-    printf("   Method         Device Exchange (avg, min, max)  Device Exchange (GPU-aware)      Host Exchange \n");
+    printf("   Method         Device Exchange (min, avg, max)  Device Exchange (GPU-aware)      Host Exchange \n");
 #else
   if (rank==0 && verbose)
-    printf("   Method         Device Exchange (avg, min, max)  Host Exchange \n");
+    printf("   Method         Device Exchange (min, avg, max)  Host Exchange \n");
 #endif
 
   //Trigger JIT kernel builds
@@ -172,9 +193,17 @@ ogsExchange_t* ogsBase_t::AutoSetup(dlong Nshared,
   /********************************
    * Pairwise
    ********************************/
-  ogsExchange_t* pairwise = new ogsPairwise_t(Nshared, sharedNodes,
-                                              _gatherHalo, dataStream,
-                                              comm, platform);
+  ogsExchange_t* pairwise = new ogsPairwise_t(knd,
+                                              Nshared,
+                                              sharedRemoteRanks,
+                                              sharedLocalRows,
+                                              sharedRemoteRows,
+                                              sharedLocalBaseIds,
+                                              sharedRemoteBaseIds,
+                                              _gatherHalo,
+                                              dataStream,
+                                              comm,
+                                              platform);
 
   //standard copy to host - exchange - copy back to device
   pairwise->gpu_aware=false;
@@ -221,9 +250,17 @@ ogsExchange_t* ogsBase_t::AutoSetup(dlong Nshared,
   /********************************
    * All-to-All
    ********************************/
-  ogsExchange_t* alltoall = new ogsAllToAll_t(Nshared, sharedNodes,
-                                           _gatherHalo, dataStream,
-                                           comm, platform);
+  ogsExchange_t* alltoall = new ogsAllToAll_t(knd,
+                                              Nshared,
+                                              sharedRemoteRanks,
+                                              sharedLocalRows,
+                                              sharedRemoteRows,
+                                              sharedLocalBaseIds,
+                                              sharedRemoteBaseIds,
+                                              _gatherHalo,
+                                              dataStream,
+                                              comm,
+                                              platform);
   //standard copy to host - exchange - copy back to device
   alltoall->gpu_aware=false;
 
@@ -274,9 +311,18 @@ ogsExchange_t* ogsBase_t::AutoSetup(dlong Nshared,
   /********************************
    * Crystal Router
    ********************************/
-  ogsExchange_t* crystal = new ogsCrystalRouter_t(Nshared, sharedNodes,
-                                                 _gatherHalo, dataStream,
-                                                 comm, platform);
+  ogsExchange_t* crystal = new ogsCrystalRouter_t(knd,
+                                                  Nshared,
+                                                  sharedRemoteRanks,
+                                                  sharedLocalRows,
+                                                  sharedRemoteRows,
+                                                  sharedLocalBaseIds,
+                                                  sharedRemoteBaseIds,
+                                                  haloBaseIds,
+                                                  _gatherHalo,
+                                                  dataStream,
+                                                  comm,
+                                                  platform);
 
   //standard copy to host - exchange - copy back to device
   crystal->gpu_aware=false;

--- a/libs/ogs/ogsHalo.cpp
+++ b/libs/ogs/ogsHalo.cpp
@@ -46,20 +46,20 @@ template<typename T>
 void halo_t::ExchangeStart(deviceMemory<T> o_v, const int k){
   exchange->AllocBuffer(k*sizeof(T));
 
-  deviceMemory<T> o_haloBuf = exchange->o_workspace;
+  deviceMemory<T> o_sendBuf = exchange->getDeviceSendBuffer();
 
   if (exchange->gpu_aware) {
     if (gathered_halo) {
       //if this halo was build from a gathered ogs the halo nodes are at the end
-      o_haloBuf.copyFrom(o_v + k*NlocalT, k*NhaloP,
+      o_sendBuf.copyFrom(o_v + k*NlocalT, k*NhaloP,
                          0, properties_t("async", true));
     } else {
       //collect halo buffer
-      gatherHalo->Gather(o_haloBuf, o_v, k, Add, NoTrans);
+      gatherHalo->Gather(o_sendBuf, o_v, k, Add, NoTrans);
     }
 
     //prepare MPI exchange
-    exchange->Start(o_haloBuf, k, Add, NoTrans);
+    exchange->DeviceStart(ogsType<T>::get(), k, Add, NoTrans);
 
   } else {
     //get current stream
@@ -67,7 +67,7 @@ void halo_t::ExchangeStart(deviceMemory<T> o_v, const int k){
     stream_t currentStream = device.getStream();
 
     //if not using gpu-aware mpi move the halo buffer to the host
-    pinnedMemory<T> haloBuf = exchange->h_workspace;
+    pinnedMemory<T> sendBuf = exchange->getHostSendBuffer();
 
     if (gathered_halo) {
       //wait for o_v to be ready
@@ -75,19 +75,19 @@ void halo_t::ExchangeStart(deviceMemory<T> o_v, const int k){
 
       //queue copy to host
       device.setStream(dataStream);
-      haloBuf.copyFrom(o_v + k*NlocalT, NhaloP*k,
+      sendBuf.copyFrom(o_v + k*NlocalT, NhaloP*k,
                        0, properties_t("async", true));
       device.setStream(currentStream);
     } else {
       //collect halo buffer
-      gatherHalo->Gather(o_haloBuf, o_v, k, Add, NoTrans);
+      gatherHalo->Gather(o_sendBuf, o_v, k, Add, NoTrans);
 
       //wait for o_haloBuf to be ready
       device.finish();
 
       //queue copy to host
       device.setStream(dataStream);
-      haloBuf.copyFrom(o_haloBuf, NhaloP*k,
+      sendBuf.copyFrom(o_sendBuf, NhaloP*k,
                        0, properties_t("async", true));
       device.setStream(currentStream);
     }
@@ -97,22 +97,21 @@ void halo_t::ExchangeStart(deviceMemory<T> o_v, const int k){
 template<typename T>
 void halo_t::ExchangeFinish(deviceMemory<T> o_v, const int k){
 
-  deviceMemory<T> o_haloBuf = exchange->o_workspace;
 
   //write exchanged halo buffer back to vector
   if (exchange->gpu_aware) {
     //finish MPI exchange
-    exchange->Finish(o_haloBuf, k, Add, NoTrans);
+    exchange->DeviceFinish(ogsType<T>::get(), k, Add, NoTrans);
+
+    deviceMemory<T> o_recvBuf = exchange->getDeviceRecvBuffer();
 
     if (gathered_halo) {
-      o_haloBuf.copyTo(o_v + k*(NlocalT+NhaloP), k*Nhalo,
+      o_recvBuf.copyTo(o_v + k*(NlocalT+NhaloP), k*Nhalo,
                        k*NhaloP, properties_t("async", true));
     } else {
-      gatherHalo->Scatter(o_v, o_haloBuf, k, NoTrans);
+      gatherHalo->Scatter(o_v, o_recvBuf, k, NoTrans);
     }
   } else {
-    pinnedMemory<T> haloBuf = exchange->h_workspace;
-
     //get current stream
     device_t &device = platform.device;
     stream_t currentStream = device.getStream();
@@ -122,22 +121,25 @@ void halo_t::ExchangeFinish(deviceMemory<T> o_v, const int k){
     device.finish();
 
     /*MPI exchange of host buffer*/
-    exchange->Start (haloBuf, k, Add, NoTrans);
-    exchange->Finish(haloBuf, k, Add, NoTrans);
+    exchange->HostStart (ogsType<T>::get(), k, Add, NoTrans);
+    exchange->HostFinish(ogsType<T>::get(), k, Add, NoTrans);
+
+    pinnedMemory<T> recvBuf = exchange->getHostRecvBuffer();
+    deviceMemory<T> o_recvBuf = exchange->getDeviceRecvBuffer();
 
     // copy recv back to device
     if (gathered_halo) {
-      haloBuf.copyTo(o_v + k*(NlocalT+NhaloP), k*Nhalo,
+      recvBuf.copyTo(o_v + k*(NlocalT+NhaloP), k*Nhalo,
                      k*NhaloP, properties_t("async", true));
       device.finish(); //wait for transfer to finish
       device.setStream(currentStream);
     } else {
-      haloBuf.copyTo(o_haloBuf+k*NhaloP, k*Nhalo,
+      recvBuf.copyTo(o_recvBuf+k*NhaloP, k*Nhalo,
                      k*NhaloP, properties_t("async", true));
       device.finish(); //wait for transfer to finish
       device.setStream(currentStream);
 
-      gatherHalo->Scatter(o_v, o_haloBuf, k, NoTrans);
+      gatherHalo->Scatter(o_v, o_recvBuf, k, NoTrans);
     }
   }
 }
@@ -158,36 +160,36 @@ template<typename T>
 void halo_t::ExchangeStart(memory<T> v, const int k) {
   exchange->AllocBuffer(k*sizeof(T));
 
-  pinnedMemory<T> haloBuf = exchange->h_workspace;
+  pinnedMemory<T> sendBuf = exchange->getHostSendBuffer();
 
   //collect halo buffer
   if (gathered_halo) {
     //if this halo was build from a gathered ogs the halo nodes are at the end
-    haloBuf.copyFrom(v + k*NlocalT, k*NhaloP);
+    sendBuf.copyFrom(v + k*NlocalT, k*NhaloP);
   } else {
-    gatherHalo->Gather(haloBuf, v, k, Add, NoTrans);
+    gatherHalo->Gather(sendBuf, v, k, Add, NoTrans);
   }
 
   //Prepare MPI exchange
-  exchange->Start(haloBuf, k, Add, NoTrans);
+  exchange->HostStart(ogsType<T>::get(), k, Add, NoTrans);
 }
 
 template<typename T>
 void halo_t::ExchangeFinish(memory<T> v, const int k) {
 
-  pinnedMemory<T> haloBuf = exchange->h_workspace;
-
   //finish MPI exchange
-  exchange->Finish(haloBuf, k, Add, NoTrans);
+  exchange->HostFinish(ogsType<T>::get(), k, Add, NoTrans);
+
+  pinnedMemory<T> recvBuf = exchange->getHostRecvBuffer();
 
   //write exchanged halo buffer back to vector
   if (gathered_halo) {
     //if this halo was build from a gathered ogs the halo nodes are at the end
-    haloBuf.copyTo(v + k*(NlocalT+NhaloP),
+    recvBuf.copyTo(v + k*(NlocalT+NhaloP),
                    k*Nhalo,
                    k*NhaloP);
   } else {
-    gatherHalo->Scatter(v, haloBuf, k, NoTrans);
+    gatherHalo->Scatter(v, recvBuf, k, NoTrans);
   }
 }
 
@@ -209,27 +211,27 @@ template<typename T>
 void halo_t::CombineStart(deviceMemory<T> o_v, const int k){
   exchange->AllocBuffer(k*sizeof(T));
 
-  deviceMemory<T> o_haloBuf = exchange->o_workspace;
+  deviceMemory<T> o_sendBuf = exchange->getDeviceSendBuffer();
 
   if (exchange->gpu_aware) {
     if (gathered_halo) {
       //if this halo was build from a gathered ogs the halo nodes are at the end
-      o_haloBuf.copyFrom(o_v + k*NlocalT, k*NhaloT,
+      o_sendBuf.copyFrom(o_v + k*NlocalT, k*NhaloT,
                          0, properties_t("async", true));
     } else {
       //collect halo buffer
-      gatherHalo->Gather(o_haloBuf, o_v, k, Add, Trans);
+      gatherHalo->Gather(o_sendBuf, o_v, k, Add, Trans);
     }
 
     //prepare MPI exchange
-    exchange->Start(o_haloBuf, k, Add, Trans);
+    exchange->DeviceStart(ogsType<T>::get(), k, Add, Trans);
   } else {
     //get current stream
     device_t &device = platform.device;
     stream_t currentStream = device.getStream();
 
     //if not using gpu-aware mpi move the halo buffer to the host
-    pinnedMemory<T> haloBuf = exchange->h_workspace;
+    pinnedMemory<T> sendBuf = exchange->getHostSendBuffer();
 
     if (gathered_halo) {
       //wait for o_v to be ready
@@ -237,19 +239,19 @@ void halo_t::CombineStart(deviceMemory<T> o_v, const int k){
 
       //queue copy to host
       device.setStream(dataStream);
-      haloBuf.copyFrom(o_v + k*NlocalT, NhaloT*k,
+      sendBuf.copyFrom(o_v + k*NlocalT, NhaloT*k,
                        0, properties_t("async", true));
       device.setStream(currentStream);
     } else {
       //collect halo buffer
-      gatherHalo->Gather(o_haloBuf, o_v, k, Add, Trans);
+      gatherHalo->Gather(o_sendBuf, o_v, k, Add, Trans);
 
-      //wait for o_haloBuf to be ready
+      //wait for o_sendBuf to be ready
       device.finish();
 
       //queue copy to host
       device.setStream(dataStream);
-      haloBuf.copyFrom(o_haloBuf, NhaloT*k,
+      sendBuf.copyFrom(o_sendBuf, NhaloT*k,
                        0, properties_t("async", true));
       device.setStream(currentStream);
     }
@@ -259,22 +261,22 @@ void halo_t::CombineStart(deviceMemory<T> o_v, const int k){
 template<typename T>
 void halo_t::CombineFinish(deviceMemory<T> o_v, const int k){
 
-  deviceMemory<T> o_haloBuf = exchange->o_workspace;
 
   //write exchanged halo buffer back to vector
   if (exchange->gpu_aware) {
     //finish MPI exchange
-    exchange->Finish(o_haloBuf, k, Add, Trans);
+    exchange->DeviceFinish(ogsType<T>::get(), k, Add, Trans);
+
+    deviceMemory<T> o_recvBuf = exchange->getDeviceRecvBuffer();
 
     if (gathered_halo) {
       //if this halo was build from a gathered ogs the halo nodes are at the end
-      o_haloBuf.copyTo(o_v + k*NlocalT, k*NhaloP,
+      o_recvBuf.copyTo(o_v + k*NlocalT, k*NhaloP,
                        0, properties_t("async", true));
     } else {
-      gatherHalo->Scatter(o_v, o_haloBuf, k, Trans);
+      gatherHalo->Scatter(o_v, o_recvBuf, k, Trans);
     }
   } else {
-    pinnedMemory<T> haloBuf = exchange->h_workspace;
 
     //get current stream
     device_t &device = platform.device;
@@ -285,22 +287,25 @@ void halo_t::CombineFinish(deviceMemory<T> o_v, const int k){
     device.finish();
 
     /*MPI exchange of host buffer*/
-    exchange->Start (haloBuf, k, Add, Trans);
-    exchange->Finish(haloBuf, k, Add, Trans);
+    exchange->HostStart (ogsType<T>::get(), k, Add, Trans);
+    exchange->HostFinish(ogsType<T>::get(), k, Add, Trans);
+
+    pinnedMemory<T> recvBuf = exchange->getHostRecvBuffer();
+    deviceMemory<T> o_recvBuf = exchange->getDeviceRecvBuffer();
 
     if (gathered_halo) {
       // copy recv back to device
-      haloBuf.copyTo(o_v + k*NlocalT, NhaloP*k,
+      recvBuf.copyTo(o_v + k*NlocalT, NhaloP*k,
                      0, properties_t("async", true));
       device.finish(); //wait for transfer to finish
       device.setStream(currentStream);
     } else {
-      haloBuf.copyTo(o_haloBuf, NhaloP*k,
+      recvBuf.copyTo(o_recvBuf, NhaloP*k,
                      0, properties_t("async", true));
       device.finish(); //wait for transfer to finish
       device.setStream(currentStream);
 
-      gatherHalo->Scatter(o_v, o_haloBuf, k, Trans);
+      gatherHalo->Scatter(o_v, o_recvBuf, k, Trans);
     }
   }
 }
@@ -321,35 +326,35 @@ template<typename T>
 void halo_t::CombineStart(memory<T> v, const int k) {
   exchange->AllocBuffer(k*sizeof(T));
 
-  pinnedMemory<T> haloBuf = exchange->h_workspace;
+  pinnedMemory<T> sendBuf = exchange->getHostSendBuffer();
 
   //collect halo buffer
   if (gathered_halo) {
     //if this halo was build from a gathered ogs the halo nodes are at the end
-    haloBuf.copyFrom(v + k*NlocalT, k*NhaloT);
+    sendBuf.copyFrom(v + k*NlocalT, k*NhaloT);
   } else {
-    gatherHalo->Gather(haloBuf, v, k, Add, Trans);
+    gatherHalo->Gather(sendBuf, v, k, Add, Trans);
   }
 
   //Prepare MPI exchange
-  exchange->Start(haloBuf, k, Add, Trans);
+  exchange->HostStart(ogsType<T>::get(), k, Add, Trans);
 }
 
 
 template<typename T>
 void halo_t::CombineFinish(memory<T> v, const int k) {
 
-  pinnedMemory<T> haloBuf = exchange->h_workspace;
-
   //finish MPI exchange
-  exchange->Finish(haloBuf, k, Add, Trans);
+  exchange->HostFinish(ogsType<T>::get(), k, Add, Trans);
+
+  pinnedMemory<T> recvBuf = exchange->getHostRecvBuffer();
 
   //write exchanged halo buffer back to vector
   if (gathered_halo) {
     //if this halo was build from a gathered ogs the halo nodes are at the end
-    haloBuf.copyTo(v + k*NlocalT, k*NhaloP);
+    recvBuf.copyTo(v + k*NlocalT, k*NhaloP);
   } else {
-    gatherHalo->Scatter(v, haloBuf, k, Trans);
+    gatherHalo->Scatter(v, recvBuf, k, Trans);
   }
 }
 

--- a/libs/ogs/ogsOperator.cpp
+++ b/libs/ogs/ogsOperator.cpp
@@ -28,6 +28,7 @@ SOFTWARE.
 #include "ogs.hpp"
 #include "ogs/ogsUtils.hpp"
 #include "ogs/ogsOperator.hpp"
+#include "primitives.hpp"
 
 namespace libp {
 
@@ -444,71 +445,175 @@ template
 void ogsOperator_t::GatherScatter(deviceMemory<long long int> v,const int k,
                                   const Op op, const Transpose trans);
 
-void ogsOperator_t::setupRowBlocks() {
+/*
+Binary search for the first entry between v[start] and v[end]
+which is >= val. Returns end if no such index exist
+*/
+static dlong upperBound(dlong first,
+                        dlong last,
+                        const dlong *v,
+                        const dlong val) {
 
-  dlong blockSumN=0, blockSumT=0;
-  NrowBlocksN=0, NrowBlocksT=0;
+  dlong count = last - first;
 
-  if (NrowsN) NrowBlocksN++;
-  if (NrowsT) NrowBlocksT++;
+  while (count > 0) {
+    const dlong step = count / 2;
+    const dlong mid = first + step;
 
-  for (dlong i=0;i<NrowsT;i++) {
-    const dlong rowSizeN  = rowStartsN[i+1]-rowStartsN[i];
-    const dlong rowSizeT  = rowStartsT[i+1]-rowStartsT[i];
-
-    //this row is pathalogically big. We can't currently run this
-    LIBP_ABORT("Multiplicity of global node id: " << i
-               << " in ogsOperator_t::setupRowBlocks is too large.",
-               rowSizeN > gatherNodesPerBlock);
-    LIBP_ABORT("Multiplicity of global node id: " << i
-               << " in ogsOperator_t::setupRowBlocks is too large.",
-               rowSizeT > gatherNodesPerBlock);
-
-    if (blockSumN+rowSizeN > gatherNodesPerBlock) { //adding this row will exceed the nnz per block
-      NrowBlocksN++; //count the previous block
-      blockSumN=rowSizeN; //start a new row block
+    if (v[mid] < val) {
+      first = mid + 1;
+      count -= step + 1;
     } else {
-      blockSumN+=rowSizeN; //add this row to the block
-    }
-
-    if (blockSumT+rowSizeT > gatherNodesPerBlock) { //adding this row will exceed the nnz per block
-      NrowBlocksT++; //count the previous block
-      blockSumT=rowSizeT; //start a new row block
-    } else {
-      blockSumT+=rowSizeT; //add this row to the block
+      count = step;
     }
   }
 
-  blockRowStartsN.calloc(NrowBlocksN+1);
-  blockRowStartsT.calloc(NrowBlocksT+1);
+  return first;
+}
 
-  blockSumN=0, blockSumT=0;
-  NrowBlocksN=0, NrowBlocksT=0;
-  if (NrowsN) NrowBlocksN++;
-  if (NrowsT) NrowBlocksT++;
+static void blockRows(const dlong Nrows,
+                      const memory<dlong> rowStarts,
+                      dlong& Nblocks,
+                      memory<dlong>& blockStarts) {
 
-  for (dlong i=0;i<NrowsT;i++) {
-    const dlong rowSizeN  = rowStartsN[i+1]-rowStartsN[i];
-    const dlong rowSizeT  = rowStartsT[i+1]-rowStartsT[i];
+  if (!Nrows) return;
 
-    if (blockSumN+rowSizeN > gatherNodesPerBlock) { //adding this row will exceed the nnz per block
-      blockRowStartsN[NrowBlocksN++] = i; //mark the previous block
-      blockSumN=rowSizeN; //start a new row block
-    } else {
-      blockSumN+=rowSizeN; //add this row to the block
+  //Check for a pathalogically big row. We can't currently run this
+  memory<dlong> rowSizes(Nrows+1);
+  prim::adjacentDifference(Nrows+1, rowStarts, rowSizes);
+  dlong maxRowSize = prim::max(Nrows, rowSizes);
+  rowSizes.free();
+
+  LIBP_ABORT("Multiplicity of a global node in ogsOperator_t::setupRowBlocks is too large.",
+             maxRowSize > gatherNodesPerBlock);
+
+  // We're going to resursively bisect the list of rows into blocks,
+  //  so we need the scratch space to be some power of 2.
+  //  Worst case is every block as only one row,
+  //  so scratch space is at most Nrows blocks
+  dlong maxNblocks = 1;
+  while (maxNblocks < Nrows) { maxNblocks *= 2; }
+
+  memory<dlong> blockStartsOld(maxNblocks+1);
+  memory<dlong> blockStartsNew(maxNblocks+1);
+  memory<dlong> blockSizes(maxNblocks);
+
+  Nblocks = 1;
+  blockStartsOld[0] = 0;
+  blockStartsOld[1] = Nrows;
+  blockStartsNew[0] = 0;
+
+  blockSizes[0] = rowStarts[Nrows];
+  dlong maxSize = blockSizes[0];
+
+  while (maxSize > gatherNodesPerBlock) {
+    blockStartsNew[2*Nblocks] = Nrows;
+    /*Recursively bisect the list of rows until the max block size is < gatherNodesPerBlock*/
+    #pragma omp parallel for
+    for (dlong n=0;n<Nblocks;++n) {
+      const dlong start = blockStartsOld[n];
+      const dlong end   = blockStartsOld[n+1];
+      const dlong rowBlockSize = rowStarts[end] - rowStarts[start];
+
+      if (rowBlockSize > gatherNodesPerBlock) {
+        //Find the index ~middle of this block
+        const dlong midSize = rowStarts[start] + (rowBlockSize + 1)/2;
+        dlong mid = upperBound(start, end, rowStarts.ptr(), midSize);
+        if (mid == end) --mid; // need at least one row in the right block
+        blockStartsNew[2*n] = start;
+        blockStartsNew[2*n+1] = mid;
+        blockSizes[2*n] = rowStarts[mid] - rowStarts[start];
+        blockSizes[2*n+1] = rowStarts[end] - rowStarts[mid];
+      } else {
+        blockStartsNew[2*n] = start;
+        blockStartsNew[2*n+1] = end;
+        blockSizes[2*n] = rowBlockSize;
+        blockSizes[2*n+1] = 0;
+      }
     }
-    if (blockSumT+rowSizeT > gatherNodesPerBlock) { //adding this row will exceed the nnz per block
-      blockRowStartsT[NrowBlocksT++] = i; //mark the previous block
-      blockSumT=rowSizeT; //start a new row block
-    } else {
-      blockSumT+=rowSizeT; //add this row to the block
-    }
+
+    //swap blockStarts arrays
+    blockStartsOld.swap(blockStartsNew);
+
+    //Check if we're done bisecting
+    Nblocks *= 2;
+    maxSize = prim::max(Nblocks, blockSizes);
   }
-  blockRowStartsN[NrowBlocksN] = NrowsN;
-  blockRowStartsT[NrowBlocksT] = NrowsT;
 
-  o_blockRowStartsN = platform.malloc(blockRowStartsN);
+  dlong Nunique=0;
+  prim::unique(Nblocks+1, blockStartsOld, Nunique, blockStarts);
+  Nblocks = Nunique-1;
+}
+
+//Make gather operator using nodes list. List of non-zeros must be sorted by row index
+ogsOperator_t::ogsOperator_t(platform_t &platform_,
+                             Kind kind_,
+                             const dlong NrowsN_,
+                             const dlong NrowsT_,
+                             const dlong Ncols_,
+                             const dlong Nids,
+                             memory<hlong> baseIds,
+                             memory<dlong> rows,
+                             memory<dlong> cols):
+  platform(platform_),
+  Ncols(Ncols_),
+  NrowsN(NrowsN_),
+  NrowsT(NrowsT_),
+  kind(kind_)
+{
+  nnzT = Nids;
+  rowStartsT.malloc(NrowsT+1);
+  prim::runLengthEncodeConsecutive(nnzT, rows, NrowsT, rowStartsT);
+
+  colIdsT = cols;
+
+  o_rowStartsT = platform.malloc(rowStartsT);
+  o_colIdsT = platform.malloc(colIdsT);
+
+  if (kind == Signed) {
+    memory<int> flags(Nids);
+
+    #pragma omp parallel for
+    for (dlong n=0;n<Nids;++n) {
+      flags[n] = (baseIds[n]>0) ? 1 : 0;
+    }
+
+    nnzN = prim::count(Nids, flags, 1);
+    memory<dlong> idsN(nnzN);
+    prim::select(Nids, flags, 1, idsN);
+
+    memory<dlong> rowsN(nnzN);
+    prim::transformGather(nnzN, idsN, rows, rowsN);
+
+    rowStartsN.malloc(NrowsN+1);
+    prim::runLengthEncodeConsecutive(nnzN, rowsN, NrowsN, rowStartsN);
+
+    colIdsN.malloc(nnzN);
+    prim::transformGather(nnzN, idsN, cols, colIdsN);
+
+    o_rowStartsN = platform.malloc(rowStartsN);
+    o_colIdsN = platform.malloc(colIdsN);
+  } else {
+    nnzN = nnzT;
+    rowStartsN = rowStartsT;
+    colIdsN = colIdsT;
+    o_rowStartsN = o_rowStartsT;
+    o_colIdsN = o_colIdsT;
+  }
+
+  //divide the list of colIds into roughly equal sized blocks so that each
+  // threadblock loads approximately an equal amount of data
+  blockRows(NrowsT, rowStartsT, NrowBlocksT, blockRowStartsT);
   o_blockRowStartsT = platform.malloc(blockRowStartsT);
+
+  if (kind==Signed) {
+    blockRows(NrowsN, rowStartsN, NrowBlocksN, blockRowStartsN);
+    o_blockRowStartsN = platform.malloc(blockRowStartsN);
+  } else {
+    NrowBlocksN = NrowBlocksT;
+    blockRowStartsN = blockRowStartsT;
+    o_blockRowStartsN = o_blockRowStartsT;
+  }
 }
 
 void ogsOperator_t::Free() {

--- a/libs/ogs/ogsPairwise.cpp
+++ b/libs/ogs/ogsPairwise.cpp
@@ -27,13 +27,7 @@ SOFTWARE.
 #include "ogs.hpp"
 #include "ogs/ogsUtils.hpp"
 #include "ogs/ogsExchange.hpp"
-
-#ifdef GLIBCXX_PARALLEL
-#include <parallel/algorithm>
-using __gnu_parallel::sort;
-#else
-using std::sort;
-#endif
+#include "primitives.hpp"
 
 namespace libp {
 
@@ -43,156 +37,236 @@ namespace ogs {
 * Host exchange
 ***********************************/
 template<typename T>
-inline void ogsPairwise_t::Start(pinnedMemory<T> &buf, const int k,
-                          const Op op, const Transpose trans){
+inline void ogsPairwise_t::HostStart(const int k, const Op op, const Transpose trans){
 
   pinnedMemory<T> sendBuf = h_sendspace;
+  pinnedMemory<T> workBuf = h_workspace;
 
-  const int NranksSend  = (trans==NoTrans) ? NranksSendN  : NranksSendT;
-  const int NranksRecv  = (trans==NoTrans) ? NranksRecvN  : NranksRecvT;
-  const int *sendRanks  = (trans==NoTrans) ? sendRanksN.ptr()   : sendRanksT.ptr();
-  const int *recvRanks  = (trans==NoTrans) ? recvRanksN.ptr()   : recvRanksT.ptr();
-  const int *sendCounts = (trans==NoTrans) ? sendCountsN.ptr()  : sendCountsT.ptr();
-  const int *recvCounts = (trans==NoTrans) ? recvCountsN.ptr()  : recvCountsT.ptr();
-  const int *sendOffsets= (trans==NoTrans) ? sendOffsetsN.ptr() : sendOffsetsT.ptr();
-  const int *recvOffsets= (trans==NoTrans) ? recvOffsetsN.ptr() : recvOffsetsT.ptr();
+  // Get the exchange data based on the mode
+  data_t& d = data[trans];
+
+  // extract the send buffer
+  extract(d.Nsend, k, d.sendIds, sendBuf, workBuf);
 
   //post recvs
-  for (int r=0;r<NranksRecv;r++) {
-    comm.Irecv(buf + Nhalo*k + recvOffsets[r]*k,
-               recvRanks[r],
-               k*recvCounts[r],
-               recvRanks[r],
+  for (int r=0;r<d.NranksRecv;r++) {
+    comm.Irecv(sendBuf + d.NrowsP*k + d.recvOffsets[r]*k,
+               d.recvRanks[r],
+               k*d.recvCounts[r],
+               d.recvRanks[r],
                requests[r]);
   }
 
-  // extract the send buffer
-  if (trans == NoTrans)
-    extract(NsendN, k, sendIdsN, buf, sendBuf);
-  else
-    extract(NsendT, k, sendIdsT, buf, sendBuf);
-
   //post sends
-  for (int r=0;r<NranksSend;r++) {
-    comm.Isend(sendBuf + sendOffsets[r]*k,
-              sendRanks[r],
-              k*sendCounts[r],
+  for (int r=0;r<d.NranksSend;r++) {
+    comm.Isend(workBuf + d.sendOffsets[r]*k,
+              d.sendRanks[r],
+              k*d.sendCounts[r],
               rank,
-              requests[NranksRecv+r]);
+              requests[d.NranksRecv+r]);
   }
 }
 
 template<typename T>
-inline void ogsPairwise_t::Finish(pinnedMemory<T> &buf, const int k,
-                           const Op op, const Transpose trans){
+inline void ogsPairwise_t::HostFinish(const int k, const Op op, const Transpose trans){
 
-  const int NranksSend  = (trans==NoTrans) ? NranksSendN  : NranksSendT;
-  const int NranksRecv  = (trans==NoTrans) ? NranksRecvN  : NranksRecvT;
-  const int *recvOffsets= (trans==NoTrans) ? recvOffsetsN.ptr() : recvOffsetsT.ptr();
+  pinnedMemory<T> sendBuf = h_sendspace;
+  pinnedMemory<T> recvBuf = h_recvspace;
 
-  comm.Waitall(NranksRecv+NranksSend, requests);
+  // Get the exchange data based on the mode
+  data_t& d = data[trans];
 
-  //if we recvieved anything via MPI, gather the recv buffer and scatter
-  // it back to to original vector
-  dlong Nrecv = recvOffsets[NranksRecv];
-  if (Nrecv) {
-    // gather the recieved nodes
-    postmpi.Gather(buf, buf, k, op, trans);
-  }
+  comm.Waitall(d.NranksRecv+d.NranksSend, requests);
+
+  // gather the recieved nodes
+  d.postmpi.Gather(recvBuf, sendBuf, k, op, Sym);
 }
 
-void ogsPairwise_t::Start(pinnedMemory<float> &buf, const int k, const Op op, const Transpose trans) { Start<float>(buf, k, op, trans); }
-void ogsPairwise_t::Start(pinnedMemory<double> &buf, const int k, const Op op, const Transpose trans) { Start<double>(buf, k, op, trans); }
-void ogsPairwise_t::Start(pinnedMemory<int> &buf, const int k, const Op op, const Transpose trans) { Start<int>(buf, k, op, trans); }
-void ogsPairwise_t::Start(pinnedMemory<long long int> &buf, const int k, const Op op, const Transpose trans) { Start<long long int>(buf, k, op, trans); }
-void ogsPairwise_t::Finish(pinnedMemory<float> &buf, const int k, const Op op, const Transpose trans) { Finish<float>(buf, k, op, trans); }
-void ogsPairwise_t::Finish(pinnedMemory<double> &buf, const int k, const Op op, const Transpose trans) { Finish<double>(buf, k, op, trans); }
-void ogsPairwise_t::Finish(pinnedMemory<int> &buf, const int k, const Op op, const Transpose trans) { Finish<int>(buf, k, op, trans); }
-void ogsPairwise_t::Finish(pinnedMemory<long long int> &buf, const int k, const Op op, const Transpose trans) { Finish<long long int>(buf, k, op, trans); }
+void ogsPairwise_t::HostStart(const Type type, const int k, const Op op, const Transpose trans) {
+  switch (type) {
+    case Int32:  HostStart<int>(k, op, trans); break;
+    case Int64:  HostStart<long long int>(k, op, trans); break;
+    case Float:  HostStart<float>(k, op, trans); break;
+    case Double: HostStart<double>(k, op, trans); break;
+  }
+}
+void ogsPairwise_t::HostFinish(const Type type, const int k, const Op op, const Transpose trans) {
+  switch (type) {
+    case Int32:  HostFinish<int>(k, op, trans); break;
+    case Int64:  HostFinish<long long int>(k, op, trans); break;
+    case Float:  HostFinish<float>(k, op, trans); break;
+    case Double: HostFinish<double>(k, op, trans); break;
+  }
+}
 
 /**********************************
 * GPU-aware exchange
 ***********************************/
 template<typename T>
-void ogsPairwise_t::Start(deviceMemory<T> &o_buf,
-                          const int k,
-                          const Op op,
-                          const Transpose trans){
+void ogsPairwise_t::DeviceStart(const int k, const Op op, const Transpose trans){
 
-  const dlong Nsend = (trans == NoTrans) ? NsendN : NsendT;
+  deviceMemory<T> o_sendBuf = o_sendspace;
+  deviceMemory<T> o_workBuf = o_workspace;
 
-  if (Nsend) {
-    deviceMemory<T> o_sendBuf = o_sendspace;
+  // Get the exchange data based on the mode
+  data_t& d = data[trans];
 
-    //  assemble the send buffer on device
-    if (trans == NoTrans) {
-      extractKernel[ogsType<T>::get()](NsendN, k, o_sendIdsN, o_buf, o_sendBuf);
-    } else {
-      extractKernel[ogsType<T>::get()](NsendT, k, o_sendIdsT, o_buf, o_sendBuf);
-    }
-    //wait for kernel to finish on default stream
+  //  assemble the send buffer on device
+  extractKernel[ogsType<T>::get()](d.Nsend, k, d.o_sendIds, o_sendBuf, o_workBuf);
+
+  //wait for kernel to finish on default stream
+  if (d.Nsend) {
     device_t &device = platform.device;
     device.finish();
   }
 }
 
 template<typename T>
-void ogsPairwise_t::Finish(deviceMemory<T> &o_buf,
-                           const int k,
-                           const Op op,
-                           const Transpose trans){
+void ogsPairwise_t::DeviceFinish(const int k, const Op op, const Transpose trans){
 
   deviceMemory<T> o_sendBuf = o_sendspace;
+  deviceMemory<T> o_workBuf = o_workspace;
+  deviceMemory<T> o_recvBuf = o_recvspace;
 
-  const int NranksSend  = (trans==NoTrans) ? NranksSendN  : NranksSendT;
-  const int NranksRecv  = (trans==NoTrans) ? NranksRecvN  : NranksRecvT;
-  const int *sendRanks  = (trans==NoTrans) ? sendRanksN.ptr()   : sendRanksT.ptr();
-  const int *recvRanks  = (trans==NoTrans) ? recvRanksN.ptr()   : recvRanksT.ptr();
-  const int *sendCounts = (trans==NoTrans) ? sendCountsN.ptr()  : sendCountsT.ptr();
-  const int *recvCounts = (trans==NoTrans) ? recvCountsN.ptr()  : recvCountsT.ptr();
-  const int *sendOffsets= (trans==NoTrans) ? sendOffsetsN.ptr() : sendOffsetsT.ptr();
-  const int *recvOffsets= (trans==NoTrans) ? recvOffsetsN.ptr() : recvOffsetsT.ptr();
+  // Get the exchange data based on the mode
+  data_t& d = data[trans];
 
   //post recvs
-  for (int r=0;r<NranksRecv;r++) {
-    comm.Irecv(o_buf + Nhalo*k + recvOffsets[r]*k,
-              recvRanks[r],
-              k*recvCounts[r],
-              recvRanks[r],
+  for (int r=0;r<d.NranksRecv;r++) {
+    comm.Irecv(o_sendBuf + d.NrowsP*k + d.recvOffsets[r]*k,
+              d.recvRanks[r],
+              k*d.recvCounts[r],
+              d.recvRanks[r],
               requests[r]);
   }
 
   //post sends
-  for (int r=0;r<NranksSend;r++) {
-    comm.Isend(o_sendBuf + sendOffsets[r]*k,
-              sendRanks[r],
-              k*sendCounts[r],
+  for (int r=0;r<d.NranksSend;r++) {
+    comm.Isend(o_workBuf + d.sendOffsets[r]*k,
+              d.sendRanks[r],
+              k*d.sendCounts[r],
               rank,
-              requests[NranksRecv+r]);
+              requests[d.NranksRecv+r]);
   }
 
-  comm.Waitall(NranksRecv+NranksSend, requests);
+  comm.Waitall(d.NranksRecv+d.NranksSend, requests);
 
-  //if we recvieved anything via MPI, gather the recv buffer and scatter
-  // it back to to original vector
-  dlong Nrecv = recvOffsets[NranksRecv];
-  if (Nrecv) {
-    // gather the recieved nodes on device
-    postmpi.Gather(o_buf, o_buf, k, op, trans);
+  // gather the recieved nodes on device
+  d.postmpi.Gather(o_recvBuf, o_sendBuf, k, op, Sym);
+}
+
+void ogsPairwise_t::DeviceStart(const Type type, const int k, const Op op, const Transpose trans) {
+  switch (type) {
+    case Int32:  DeviceStart<int>(k, op, trans); break;
+    case Int64:  DeviceStart<long long int>(k, op, trans); break;
+    case Float:  DeviceStart<float>(k, op, trans); break;
+    case Double: DeviceStart<double>(k, op, trans); break;
+  }
+}
+void ogsPairwise_t::DeviceFinish(const Type type, const int k, const Op op, const Transpose trans) {
+  switch (type) {
+    case Int32:  DeviceFinish<int>(k, op, trans); break;
+    case Int64:  DeviceFinish<long long int>(k, op, trans); break;
+    case Float:  DeviceFinish<float>(k, op, trans); break;
+    case Double: DeviceFinish<double>(k, op, trans); break;
   }
 }
 
-void ogsPairwise_t::Start(deviceMemory<float> &buf, const int k, const Op op, const Transpose trans) { Start<float>(buf, k, op, trans); }
-void ogsPairwise_t::Start(deviceMemory<double> &buf, const int k, const Op op, const Transpose trans) { Start<double>(buf, k, op, trans); }
-void ogsPairwise_t::Start(deviceMemory<int> &buf, const int k, const Op op, const Transpose trans) { Start<int>(buf, k, op, trans); }
-void ogsPairwise_t::Start(deviceMemory<long long int> &buf, const int k, const Op op, const Transpose trans) { Start<long long int>(buf, k, op, trans); }
-void ogsPairwise_t::Finish(deviceMemory<float> &buf, const int k, const Op op, const Transpose trans) { Finish<float>(buf, k, op, trans); }
-void ogsPairwise_t::Finish(deviceMemory<double> &buf, const int k, const Op op, const Transpose trans) { Finish<double>(buf, k, op, trans); }
-void ogsPairwise_t::Finish(deviceMemory<int> &buf, const int k, const Op op, const Transpose trans) { Finish<int>(buf, k, op, trans); }
-void ogsPairwise_t::Finish(deviceMemory<long long int> &buf, const int k, const Op op, const Transpose trans) { Finish<long long int>(buf, k, op, trans); }
 
-ogsPairwise_t::ogsPairwise_t(dlong Nshared,
-                             memory<parallelNode_t> &sharedNodes,
+void ogsPairwise_t::data_t::setupExchange(const dlong Nsend_,
+                                          const dlong NrowsP_,
+                                          const dlong Nrows_,
+                                          const memory<int>   destRanks,
+                                          const memory<dlong> localRows,
+                                          const memory<dlong> remoteRows,
+                                          comm_t comm,
+                                          platform_t& platform) {
+
+  int size = comm.size();
+
+  Nsend = Nsend_;
+  NrowsP = NrowsP_;
+  Nrows = Nrows_;
+
+  memory<int> mpiSendCounts(size);
+  memory<int> mpiRecvCounts(size);
+  memory<int> mpiSendOffsets(size+1);
+  memory<int> mpiRecvOffsets(size+1);
+
+  /*Get length and offsets of groups of destinations*/
+  prim::runLengthEncodeConsecutive(Nsend, destRanks, size, mpiSendOffsets);
+  prim::adjacentDifference(size, mpiSendOffsets+1, mpiSendCounts);
+
+  comm.Alltoall(mpiSendCounts, mpiRecvCounts);
+  mpiRecvOffsets[0] = 0;
+  prim::inclusiveScan(size, mpiRecvCounts, mpiRecvOffsets+1);
+  dlong Nrecv = mpiRecvOffsets[size]; //total ids to recv
+
+  sendIds.malloc(Nsend);
+  sendIds.copyFrom(localRows);
+  o_sendIds = platform.malloc(sendIds);
+
+  //send the node lists so we know what we'll receive and in what order
+  Ncols = NrowsP + Nrecv;
+  memory<dlong> rows(Ncols);
+  memory<dlong> cols(Ncols);
+
+  prim::range(NrowsP, 0, 1, rows);
+
+  //Send list of rows to each rank
+  comm.Alltoallv(remoteRows,  mpiSendCounts, mpiSendOffsets,
+                 rows+NrowsP, mpiRecvCounts, mpiRecvOffsets);
+
+  /*Sort groups by their row*/
+  prim::stableSort(Ncols, rows, cols);
+
+  /*Build the gather op to assemble the recieved data from MPI*/
+  postmpi = ogsOperator_t(platform,
+                          Unsigned,
+                          Nrows,
+                          Nrows,
+                          Ncols,
+                          Ncols,
+                          memory<hlong>(),
+                          rows,
+                          cols);
+
+  //compress the send/recv counts to pairwise exchanges
+  memory<int> sendFlag(size);
+  memory<int> recvFlag(size);
+
+  #pragma omp parallel for
+  for (int r=0;r<size;++r) { sendFlag[r] = (mpiSendCounts[r]>0) ? 1 : 0; }
+
+  #pragma omp parallel for
+  for (int r=0;r<size;++r) { recvFlag[r] = (mpiRecvCounts[r]>0) ? 1 : 0; }
+
+  NranksSend = prim::count(size, sendFlag, 1);
+  NranksRecv = prim::count(size, recvFlag, 1);
+
+  sendRanks.malloc(NranksSend);
+  recvRanks.malloc(NranksRecv);
+  sendCounts.malloc(NranksSend);
+  recvCounts.malloc(NranksRecv);
+  sendOffsets.malloc(NranksSend);
+  recvOffsets.malloc(NranksRecv);
+
+  prim::select(size, sendFlag, 1, sendRanks);
+  prim::select(size, recvFlag, 1, recvRanks);
+
+  prim::transformGather(NranksSend, sendRanks, mpiSendCounts,  sendCounts);
+  prim::transformGather(NranksRecv, recvRanks, mpiRecvCounts,  recvCounts);
+  prim::transformGather(NranksSend, sendRanks, mpiSendOffsets, sendOffsets);
+  prim::transformGather(NranksRecv, recvRanks, mpiRecvOffsets, recvOffsets);
+}
+
+ogsPairwise_t::ogsPairwise_t(Kind kind,
+                             const dlong Nshared,
+                             const memory<int>   sharedRanks,
+                             const memory<dlong> sharedLocalRows,
+                             const memory<dlong> sharedRemoteRows,
+                             const memory<hlong> sharedLocalBaseIds,
+                             const memory<hlong> sharedRemoteBaseIds,
                              ogsOperator_t& gatherHalo,
                              stream_t _dataStream,
                              comm_t _comm,
@@ -202,226 +276,128 @@ ogsPairwise_t::ogsPairwise_t(dlong Nshared,
   Nhalo  = gatherHalo.NrowsT;
   NhaloP = gatherHalo.NrowsN;
 
-  // sort the list by rank to the order where they will be sent by MPI_Allgatherv
-  sort(sharedNodes.ptr(), sharedNodes.ptr()+Nshared,
-       [](const parallelNode_t& a, const parallelNode_t& b) {
-         if(a.rank < b.rank) return true; //group by rank
-         if(a.rank > b.rank) return false;
+  memory<int>   destRanks(Nshared);
+  memory<dlong> destRankSortIds(Nshared);
+  destRanks.copyFrom(sharedRanks);
 
-         return a.newId < b.newId; //then order by the localId relative to this rank
-       });
+  /*Sort list of shared nodes by rank to get the ordering for MPI Alltoallv*/
+  prim::stableSort(Nshared, destRanks, destRankSortIds);
 
-  //make mpi allgatherv counts and offsets
-  memory<int> mpiSendCountsT(size,0);
-  memory<int> mpiSendCountsN(size,0);
-  memory<int> mpiRecvCountsT(size);
-  memory<int> mpiRecvCountsN(size);
-  memory<int> mpiSendOffsetsT(size+1);
-  memory<int> mpiSendOffsetsN(size+1);
-  memory<int> mpiRecvOffsetsT(size+1);
-  memory<int> mpiRecvOffsetsN(size+1);
+  memory<dlong> localRows(Nshared);
+  prim::transformGather(Nshared, destRankSortIds, sharedLocalRows, localRows);
 
-  for (dlong n=0;n<Nshared;n++) { //loop through nodes we need to send
-    const int r = sharedNodes[n].rank;
-    if (sharedNodes[n].sign>0) mpiSendCountsN[r]++;
-    mpiSendCountsT[r]++;
-  }
+  memory<dlong> remoteRows(Nshared);
+  prim::transformGather(Nshared, destRankSortIds, sharedRemoteRows, remoteRows);
 
-  //shared counts
-  comm.Alltoall(mpiSendCountsT, mpiRecvCountsT);
-  comm.Alltoall(mpiSendCountsN, mpiRecvCountsN);
+  // Sym     mode - Send everything, gather to all Nhalo nodes
+  // NoTrans mode - Only send positive baseIds, gather to all Nhalo nodes
+  // Trans   mode - Only send to remote positive baseIds, gather to positive NhaloP nodes
 
-  //cumulative sum
-  mpiSendOffsetsN[0] = 0;
-  mpiSendOffsetsT[0] = 0;
-  mpiRecvOffsetsN[0] = 0;
-  mpiRecvOffsetsT[0] = 0;
-  for (int r=0;r<size;r++) {
-    mpiSendOffsetsN[r+1] = mpiSendOffsetsN[r]+mpiSendCountsN[r];
-    mpiSendOffsetsT[r+1] = mpiSendOffsetsT[r]+mpiSendCountsT[r];
-    mpiRecvOffsetsN[r+1] = mpiRecvOffsetsN[r]+mpiRecvCountsN[r];
-    mpiRecvOffsetsT[r+1] = mpiRecvOffsetsT[r]+mpiRecvCountsT[r];
-  }
+  /*Build the symmetric exchange using all the shared data*/
+  dlong NsendS = Nshared;
+  data[Sym].setupExchange(NsendS,
+                          Nhalo,
+                          Nhalo,
+                          destRanks,
+                          localRows,
+                          remoteRows,
+                          comm,
+                          platform);
 
-  //make ops for scattering halo nodes before sending
-  NsendN=mpiSendOffsetsN[size];
-  NsendT=mpiSendOffsetsT[size];
+  if (kind==Signed) {
+    /*Reorder baseId info*/
+    memory<hlong> localBaseIds(Nshared);
+    prim::transformGather(Nshared, destRankSortIds, sharedLocalBaseIds, localBaseIds);
 
-  sendIdsN.calloc(NsendN);
-  sendIdsT.calloc(NsendT);
+    memory<hlong> remoteBaseIds(Nshared);
+    prim::transformGather(Nshared, destRankSortIds, sharedRemoteBaseIds, remoteBaseIds);
 
-  NsendN=0; //positive node count
-  NsendT=0; //all node count
+    /*NoTrans: Get locations of shared nodes that have a local positive baseId*/
+    memory<int> noTransFlags(Nshared);
 
-  for (dlong n=0;n<Nshared;n++) { //loop through nodes we need to send
-    dlong id = sharedNodes[n].newId; //coalesced index for this baseId on this rank
-    if (sharedNodes[n].sign==2) {
-      sendIdsN[NsendN++] = id;
+    #pragma omp parallel for
+    for (dlong n=0; n<Nshared;++n) {
+      noTransFlags[n] = (localBaseIds[n]>0) ? 1 : 0;
     }
-    sendIdsT[NsendT++] = id;
-  }
-  o_sendIdsT = platform.malloc(sendIdsT);
-  o_sendIdsN = platform.malloc(sendIdsN);
 
-  //send the node lists so we know what we'll receive
-  dlong Nrecv = mpiRecvOffsetsT[size];
-  memory<parallelNode_t> recvNodes(Nrecv);
+    dlong NsendN = prim::count(Nshared, noTransFlags, 1);
+    memory<dlong> noTransIds(NsendN);
+    prim::select(Nshared, noTransFlags, 1, noTransIds);
 
-  //Send list of nodes to each rank
-  comm.Alltoallv(sharedNodes, mpiSendCountsT, mpiSendOffsetsT,
-                   recvNodes, mpiRecvCountsT, mpiRecvOffsetsT);
+    /*Extract the subset of the shared node list for these nodes*/
+    memory<int> destRanksN(NsendN);
+    prim::transformGather(NsendN, noTransIds, destRanks, destRanksN);
 
-  //make ops for gathering halo nodes after an MPI_Allgatherv
-  postmpi.platform = platform;
-  postmpi.kind = Signed;
+    memory<dlong> localRowsN(NsendN);
+    prim::transformGather(NsendN, noTransIds, localRows, localRowsN);
 
-  postmpi.NrowsN = Nhalo;
-  postmpi.NrowsT = Nhalo;
-  postmpi.rowStartsN.calloc(Nhalo+1);
-  postmpi.rowStartsT.calloc(Nhalo+1);
+    memory<dlong> remoteRowsN(NsendN);
+    prim::transformGather(NsendN, noTransIds, remoteRows, remoteRowsN);
 
-  //make array of counters
-  memory<dlong> haloGatherTCounts(Nhalo);
-  memory<dlong> haloGatherNCounts(Nhalo);
+    /*Build the NoTrans exchange*/
+    data[NoTrans].setupExchange(NsendN,
+                                NhaloP,
+                                Nhalo,
+                                destRanksN,
+                                localRowsN,
+                                remoteRowsN,
+                                comm,
+                                platform);
 
-  //count the data that will already be in h_haloBuf.ptr()
-  for (dlong n=0;n<Nhalo;n++) {
-    haloGatherNCounts[n] = (n<NhaloP) ? 1 : 0;
-    haloGatherTCounts[n] = 1;
-  }
+    /*Trans: Get locations of shared nodes that have a remote positive baseId*/
+    memory<int> transFlags(Nshared);
 
-  for (dlong n=0;n<Nrecv;n++) { //loop through nodes needed for gathering halo nodes
-    dlong id = recvNodes[n].localId; //coalesced index for this baseId on this rank
-    if (recvNodes[n].sign==2) haloGatherNCounts[id]++;  //tally
-    haloGatherTCounts[id]++;  //tally
-  }
-
-  for (dlong i=0;i<Nhalo;i++) {
-    postmpi.rowStartsN[i+1] = postmpi.rowStartsN[i] + haloGatherNCounts[i];
-    postmpi.rowStartsT[i+1] = postmpi.rowStartsT[i] + haloGatherTCounts[i];
-    haloGatherNCounts[i] = 0;
-    haloGatherTCounts[i] = 0;
-  }
-  postmpi.nnzN = postmpi.rowStartsN[Nhalo];
-  postmpi.nnzT = postmpi.rowStartsT[Nhalo];
-  postmpi.colIdsN.calloc(postmpi.nnzN);
-  postmpi.colIdsT.calloc(postmpi.nnzT);
-
-  for (dlong n=0;n<NhaloP;n++) {
-    const dlong soffset = postmpi.rowStartsN[n];
-    const int sindex  = haloGatherNCounts[n];
-    postmpi.colIdsN[soffset+sindex] = n; //record id
-    haloGatherNCounts[n]++;
-  }
-  for (dlong n=0;n<Nhalo;n++) {
-    const dlong soffset = postmpi.rowStartsT[n];
-    const int sindex  = haloGatherTCounts[n];
-    postmpi.colIdsT[soffset+sindex] = n; //record id
-    haloGatherTCounts[n]++;
-  }
-
-  dlong cnt=Nhalo; //positive node count
-  for (dlong n=0;n<Nrecv;n++) { //loop through nodes we need to send
-    dlong id = recvNodes[n].localId; //coalesced index for this baseId on this rank
-    if (recvNodes[n].sign==2) {
-      const dlong soffset = postmpi.rowStartsN[id];
-      const int sindex  = haloGatherNCounts[id];
-      postmpi.colIdsN[soffset+sindex] = cnt++; //record id
-      haloGatherNCounts[id]++;
+    #pragma omp parallel for
+    for (dlong n=0; n<Nshared;++n) {
+      transFlags[n] = (remoteBaseIds[n]>0) ? 1 : 0;
     }
-    const dlong soffset = postmpi.rowStartsT[id];
-    const int sindex  = haloGatherTCounts[id];
-    postmpi.colIdsT[soffset+sindex] = n + Nhalo; //record id
-    haloGatherTCounts[id]++;
+
+    dlong NsendT = prim::count(Nshared, transFlags, 1);
+    memory<dlong> transIds(NsendT);
+    prim::select(Nshared, transFlags,  1, transIds);
+
+    /*Extract the subset of the shared node list for these nodes*/
+    memory<int> destRanksT(NsendT);
+    prim::transformGather(NsendT, transIds, destRanks, destRanksT);
+
+    memory<dlong> localRowsT(NsendT);
+    prim::transformGather(NsendT, transIds, localRows, localRowsT);
+
+    memory<dlong> remoteRowsT(NsendT);
+    prim::transformGather(NsendT, transIds, remoteRows, remoteRowsT);
+
+    /*Build the Trans exchange*/
+    data[Trans].setupExchange(NsendT,
+                              NhaloP,
+                              NhaloP,
+                              destRanksT,
+                              localRowsT,
+                              remoteRowsT,
+                              comm,
+                              platform);
+  } else {
+    data[NoTrans] = data[Sym];
+    data[Trans] = data[Sym];
   }
 
-  postmpi.o_rowStartsN = platform.malloc(postmpi.rowStartsN);
-  postmpi.o_rowStartsT = platform.malloc(postmpi.rowStartsT);
-  postmpi.o_colIdsN = platform.malloc(postmpi.colIdsN);
-  postmpi.o_colIdsT = platform.malloc(postmpi.colIdsT);
-
-  //free up space
-  recvNodes.free();
-  haloGatherNCounts.free();
-  haloGatherTCounts.free();
-
-  postmpi.setupRowBlocks();
-
-  //compress the send/recv counts to pairwise exchanges
-  NranksSendN=0;
-  NranksSendT=0;
-  NranksRecvN=0;
-  NranksRecvT=0;
-  for (int r=0;r<size;r++) {
-    NranksSendN += (mpiSendCountsN[r]>0) ? 1 : 0;
-    NranksSendT += (mpiSendCountsT[r]>0) ? 1 : 0;
-    NranksRecvN += (mpiRecvCountsN[r]>0) ? 1 : 0;
-    NranksRecvT += (mpiRecvCountsT[r]>0) ? 1 : 0;
-  }
-
-  sendRanksN.calloc(NranksSendN);
-  sendRanksT.calloc(NranksSendT);
-  recvRanksN.calloc(NranksRecvN);
-  recvRanksT.calloc(NranksRecvT);
-  sendCountsN.calloc(NranksSendN);
-  sendCountsT.calloc(NranksSendT);
-  recvCountsN.calloc(NranksRecvN);
-  recvCountsT.calloc(NranksRecvT);
-  sendOffsetsN.calloc(NranksSendN+1);
-  sendOffsetsT.calloc(NranksSendT+1);
-  recvOffsetsN.calloc(NranksRecvN+1);
-  recvOffsetsT.calloc(NranksRecvT+1);
-
-  //reset
-  NranksSendN=0;
-  NranksSendT=0;
-  NranksRecvN=0;
-  NranksRecvT=0;
-  for (int r=0;r<size;r++) {
-    if (mpiSendCountsN[r]>0) {
-      sendRanksN[NranksSendN]  = r;
-      sendCountsN[NranksSendN] = mpiSendCountsN[r];
-      sendOffsetsN[NranksSendN] = mpiSendOffsetsN[r];
-      NranksSendN++;
-    }
-    if (mpiSendCountsT[r]>0) {
-      sendRanksT[NranksSendT]  = r;
-      sendCountsT[NranksSendT] = mpiSendCountsT[r];
-      sendOffsetsT[NranksSendT] = mpiSendOffsetsT[r];
-      NranksSendT++;
-    }
-    if (mpiRecvCountsN[r]>0) {
-      recvRanksN[NranksRecvN]   = r;
-      recvCountsN[NranksRecvN]  = mpiRecvCountsN[r];
-      recvOffsetsN[NranksRecvN] = mpiRecvOffsetsN[r];
-      NranksRecvN++;
-    }
-    if (mpiRecvCountsT[r]>0) {
-      recvRanksT[NranksRecvT]   = r;
-      recvCountsT[NranksRecvT]  = mpiRecvCountsT[r];
-      recvOffsetsT[NranksRecvT] = mpiRecvOffsetsT[r];
-      NranksRecvT++;
-    }
-  }
-  sendOffsetsN[NranksSendN] = mpiSendOffsetsN[size];
-  sendOffsetsT[NranksSendT] = mpiSendOffsetsT[size];
-  recvOffsetsN[NranksRecvN] = mpiRecvOffsetsN[size];
-  recvOffsetsT[NranksRecvT] = mpiRecvOffsetsT[size];
-
-  requests.malloc(NranksSendT+NranksRecvT);
+  requests.malloc(data[Sym].NranksSend+data[Sym].NranksRecv);
 
   //make scratch space
   AllocBuffer(sizeof(dfloat));
 }
 
 void ogsPairwise_t::AllocBuffer(size_t Nbytes) {
-  if (o_workspace.size() < postmpi.nnzT*Nbytes) {
-    h_workspace = platform.hostMalloc<char>(postmpi.nnzT*Nbytes);
-    o_workspace = platform.malloc<char>(postmpi.nnzT*Nbytes);
+  if (o_sendspace.size() < data[Sym].Ncols*Nbytes) {
+    h_sendspace = platform.hostMalloc<char>(data[Sym].Ncols*Nbytes);
+    o_sendspace = platform.malloc<char>(data[Sym].Ncols*Nbytes);
   }
-  if (o_sendspace.size() < NsendT*Nbytes) {
-    h_sendspace = platform.hostMalloc<char>(NsendT*Nbytes);
-    o_sendspace = platform.malloc<char>(NsendT*Nbytes);
+  if (o_workspace.size() < data[Sym].Nsend*Nbytes) {
+    h_workspace = platform.hostMalloc<char>(data[Sym].Nsend*Nbytes);
+    o_workspace = platform.malloc<char>(data[Sym].Nsend*Nbytes);
+  }
+  if (o_recvspace.size() < data[Sym].Nrows*Nbytes) {
+    h_recvspace = platform.hostMalloc<char>(data[Sym].Nrows*Nbytes);
+    o_recvspace = platform.malloc<char>(data[Sym].Nrows*Nbytes);
   }
 }
 

--- a/libs/ogs/ogsUtils.cpp
+++ b/libs/ogs/ogsUtils.cpp
@@ -50,14 +50,14 @@ void InitializeKernels(platform_t& platform, const Type type, const Op op) {
 
     properties_t kernelInfo = platform.props();
 
-    kernelInfo["defines/p_blockSize"] = ogsOperator_t::blockSize;
-    kernelInfo["defines/p_gatherNodesPerBlock"] = ogsOperator_t::gatherNodesPerBlock;
+    kernelInfo["defines/p_blockSize"] = ogs::blockSize;
+    kernelInfo["defines/p_gatherNodesPerBlock"] = ogs::gatherNodesPerBlock;
 
     switch (type) {
       case Float:  kernelInfo["defines/T"] =  "float"; break;
       case Double: kernelInfo["defines/T"] =  "double"; break;
-      case Int32:  kernelInfo["defines/T"] =  "int32_t"; break;
-      case Int64:  kernelInfo["defines/T"] =  "int64_t"; break;
+      case Int32:  kernelInfo["defines/T"] =  "int"; break;
+      case Int64:  kernelInfo["defines/T"] =  "long long int"; break;
     }
 
     switch (type) {

--- a/libs/primitives/adjacentDifference.cpp
+++ b/libs/primitives/adjacentDifference.cpp
@@ -1,0 +1,76 @@
+/*
+
+The MIT License (MIT)
+
+Copyright (c) 2017-2023 Tim Warburton, Noel Chalmers, Jesse Chan, Ali Karakus
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+*/
+
+#include "primitives.hpp"
+
+namespace libp {
+
+namespace prim {
+
+
+template<typename T>
+void adjacentDifference(const dlong N, const memory<T> v, memory<T> diff) {
+
+  if (N<=0) return;
+
+  diff[0] = v[0];
+
+  #pragma omp parallel for
+  for (dlong n=1; n<N; ++n) {
+    const T a = v[n-1];
+    const T b = v[n];
+    diff[n] = b - a;
+  }
+}
+
+template void adjacentDifference(const dlong N, const memory<int> v, memory<int> diff);
+template void adjacentDifference(const dlong N, const memory<long long int> v, memory<long long int> diff);
+template void adjacentDifference(const dlong N, const memory<float> v, memory<float> diff);
+template void adjacentDifference(const dlong N, const memory<double> v, memory<double> diff);
+
+template<typename T>
+void adjacentDifferenceFlag(const dlong N, const memory<T> v, memory<dlong> flag) {
+
+  if (N<=0) return;
+
+  flag[0] = 1;
+
+  #pragma omp parallel for
+  for (dlong n=1; n<N; ++n) {
+    const T a = v[n-1];
+    const T b = v[n];
+    flag[n] = (b - a) ? 1 : 0;
+  }
+}
+
+template void adjacentDifferenceFlag(const dlong N, const memory<int> v, memory<dlong> diff);
+template void adjacentDifferenceFlag(const dlong N, const memory<long long int> v, memory<dlong> diff);
+template void adjacentDifferenceFlag(const dlong N, const memory<float> v, memory<dlong> diff);
+template void adjacentDifferenceFlag(const dlong N, const memory<double> v, memory<dlong> diff);
+
+} //namespace prim
+
+} //namespace libp

--- a/libs/primitives/count.cpp
+++ b/libs/primitives/count.cpp
@@ -1,0 +1,55 @@
+/*
+
+The MIT License (MIT)
+
+Copyright (c) 2017-2023 Tim Warburton, Noel Chalmers, Jesse Chan, Ali Karakus
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+*/
+
+#include "primitives.hpp"
+
+namespace libp {
+
+namespace prim {
+
+
+template<typename T>
+dlong count(const dlong N, const memory<T> v, const T& value) {
+
+  if (N<=0) return 0;
+
+  dlong cnt = 0;
+  #pragma omp parallel for reduction(+:cnt)
+  for (dlong n=0; n<N; ++n) {
+    cnt += (v[n] == value) ? 1 : 0;
+  }
+
+  return cnt;
+}
+
+template dlong count(const dlong N, const memory<int> v, const int& value);
+template dlong count(const dlong N, const memory<long long int> v, const long long int& value);
+template dlong count(const dlong N, const memory<float> v, const float& value);
+template dlong count(const dlong N, const memory<double> v, const double& value);
+
+} //namespace prim
+
+} //namespace libp

--- a/libs/primitives/numeric.cpp
+++ b/libs/primitives/numeric.cpp
@@ -1,0 +1,82 @@
+/*
+
+The MIT License (MIT)
+
+Copyright (c) 2017-2023 Tim Warburton, Noel Chalmers, Jesse Chan, Ali Karakus
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+*/
+
+#include "primitives.hpp"
+
+namespace libp {
+
+namespace prim {
+
+template<typename T>
+void abs(const dlong N, const memory<T> v, memory<T> absv) {
+
+  if (N<=0) return;
+
+  #pragma omp parallel for
+  for(dlong n = 0; n < N; ++n){
+    absv[n] = std::abs(v[n]);
+  }
+}
+
+template void abs(const dlong N, const memory<int> v, memory<int> absv);
+template void abs(const dlong N, const memory<long long int> v, memory<long long int> absv);
+template void abs(const dlong N, const memory<float> v, memory<float> absv);
+template void abs(const dlong N, const memory<double> v, memory<double> absv);
+
+template<typename T>
+void set(const dlong N, const T val, memory<T> v) {
+
+  if (N<=0) return;
+
+  #pragma omp parallel for
+  for(dlong n = 0; n < N; ++n){
+    v[n] = val;
+  }
+}
+
+template void set(const dlong N, const int val, memory<int> v);
+template void set(const dlong N, const long long int val, memory<long long int> v);
+template void set(const dlong N, const float val, memory<float> v);
+template void set(const dlong N, const double val, memory<double> v);
+
+template<typename T>
+void range(const dlong N, const T start, const T step, memory<T> v) {
+  if (N<=0) return;
+
+  #pragma omp parallel for
+  for(dlong n = 0; n < N; ++n){
+    v[n] = start + step*n;
+  }
+}
+
+template void range(const dlong N, const int start, const int step, memory<int> v);
+template void range(const dlong N, const long long int start, const long long int step, memory<long long int> v);
+template void range(const dlong N, const float start, const float step, memory<float> v);
+template void range(const dlong N, const double start, const double step, memory<double> v);
+
+} //namespace prim
+
+} //namespace libp

--- a/libs/primitives/random.cpp
+++ b/libs/primitives/random.cpp
@@ -1,0 +1,173 @@
+/*
+
+The MIT License (MIT)
+
+Copyright (c) 2017-2023 Tim Warburton, Noel Chalmers, Jesse Chan, Ali Karakus
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+*/
+
+#include "primitives.hpp"
+#include <limits>
+#include "omp.h"
+
+namespace libp {
+
+namespace prim {
+
+/*
+The  pseudo-random  generator uses the linear congruential algorithm:
+X(n+1) = (a * X(n) + c) mod m  as  described  in the  Art of Computer
+Programming, Knuth 1973, Vol. 2.
+
+Not the best RNG, but we care about it being reasonably fast and, more
+importantly, we want prim::random to generate the same sequence of
+random numbers, whether or not it was computed in parallel
+*/
+
+#define LCG_A 6364136223846793005ULL
+#define LCG_C 1ULL
+
+#define SEED 1ULL
+
+struct RandCoeff {
+  uint64_t a;
+  uint64_t c;
+
+  static RandCoeff default_vals() { return {LCG_A, LCG_C}; }
+
+  RandCoeff operator*(const RandCoeff& rhs) const {
+    return {a * rhs.a, a * rhs.c + c};
+  }
+
+  void operator*=(const RandCoeff& rhs) {
+    c = a * rhs.c + c;
+    a = a * rhs.a;
+  }
+};
+
+RandCoeff pow(RandCoeff base, uint32_t n) {
+  RandCoeff result{1, 0};
+  while(n != 0) {
+    if(n & 1) result *= base;
+    n >>= 1;
+    base *= base;
+  }
+  return result;
+}
+
+struct RandState {
+  uint64_t x;
+
+  static RandState initialize(const uint64_t seed = SEED,
+                              RandCoeff coef = RandCoeff::default_vals()) {
+    return coef * RandState{std::numeric_limits<uint64_t>::max() ^ seed};
+  }
+
+  void operator*=(RandCoeff coef) {
+    x = coef.a * x + coef.c;
+  }
+
+  template<typename T>
+  T get();
+
+  friend RandState operator*(RandCoeff coef, RandState stat) {
+    return {coef.a * stat.x + coef.c};
+  }
+};
+
+template<>
+int RandState::get() {
+  return std::abs(static_cast<int>(x));
+}
+
+template<>
+long long int RandState::get() {
+  return std::abs(static_cast<long long int>(x));
+}
+
+template<>
+float RandState::get() {
+  return x*(1.0/std::numeric_limits<uint64_t>::max());
+}
+
+template<>
+double RandState::get() {
+  return x*(1.0/std::numeric_limits<uint64_t>::max());
+}
+
+static RandState state = RandState::initialize();
+
+
+void seedRNG(const uint64_t seed) {
+  state = RandState::initialize(seed);
+}
+
+template <typename T>
+void random(const dlong N, memory<T> v) {
+
+  constexpr int blockSize = 512;
+  const dlong Nblocks = (N+blockSize-1)/blockSize;
+
+  // compute increments
+  RandCoeff step1 = RandCoeff::default_vals();
+  RandCoeff stepBlock = pow(step1, blockSize);
+
+  #pragma omp parallel
+  {
+#if !defined(LIBP_DEBUG)
+    const int thread = omp_get_thread_num();
+    const int Nthreads = omp_get_num_threads();
+#else
+    const int thread = 0;
+    const int Nthreads = 1;
+#endif
+
+    // Get the rng state
+    RandState rng = state;
+
+    for (dlong b=0;b<Nblocks;++b) {
+      if ((b % Nthreads) == thread) { //check if my thread does this block
+        RandState curr_rng = rng;
+
+        const int M = std::min(N - b*blockSize, blockSize);
+        for (int n=0;n<M;++n) {
+          v[b*blockSize + n] = curr_rng.get<T>();
+          curr_rng *= step1;
+        }
+      }
+
+      // Shift rng down a block
+      rng *= stepBlock;
+    }
+  }
+
+  // Update the global rng state N steps
+  state *= pow(step1, N);
+}
+
+template void random(const dlong N, memory<int> v);
+template void random(const dlong N, memory<long long int> v);
+template void random(const dlong N, memory<float> v);
+template void random(const dlong N, memory<double> v);
+
+} //namespace prim
+
+} //namespace libp

--- a/libs/primitives/reduce.cpp
+++ b/libs/primitives/reduce.cpp
@@ -1,0 +1,97 @@
+/*
+
+The MIT License (MIT)
+
+Copyright (c) 2017-2023 Tim Warburton, Noel Chalmers, Jesse Chan, Ali Karakus
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+*/
+
+#include "primitives.hpp"
+#include <limits>
+
+namespace libp {
+
+namespace prim {
+
+
+template<typename T>
+T min(const dlong N, const memory<T> v) {
+
+  T min_v = std::numeric_limits<T>::max();
+
+  if (N<=0) return min_v;
+
+  #pragma omp parallel for reduction(min:min_v)
+  for(dlong n = 0; n < N; ++n){
+    min_v = std::min(min_v, v[n]);
+  }
+
+  return min_v;
+}
+
+template int min(const dlong N, const memory<int> v);
+template long long int min(const dlong N, const memory<long long int> v);
+template float min(const dlong N, const memory<float> v);
+template double min(const dlong N, const memory<double> v);
+
+template<typename T>
+T max(const dlong N, const memory<T> v) {
+
+  T max_v = -std::numeric_limits<T>::max();
+
+  if (N<=0) return max_v;
+
+  #pragma omp parallel for reduction(max:max_v)
+  for(dlong n = 0; n < N; ++n){
+    max_v = std::max(max_v, v[n]);
+  }
+
+  return max_v;
+}
+
+template int max(const dlong N, const memory<int> v);
+template long long int max(const dlong N, const memory<long long int> v);
+template float max(const dlong N, const memory<float> v);
+template double max(const dlong N, const memory<double> v);
+
+template<typename T>
+T sum(const dlong N, const memory<T> v) {
+
+  T sum_v = T{0};
+
+  if (N<=0) return sum_v;
+
+  #pragma omp parallel for reduction(+:sum_v)
+  for(dlong n = 0; n < N; ++n){
+    sum_v += v[n];
+  }
+
+  return sum_v;
+}
+
+template int sum(const dlong N, const memory<int> v);
+template long long int sum(const dlong N, const memory<long long int> v);
+template float sum(const dlong N, const memory<float> v);
+template double sum(const dlong N, const memory<double> v);
+
+} //namespace prim
+
+} //namespace libp

--- a/libs/primitives/runLengthEncode.cpp
+++ b/libs/primitives/runLengthEncode.cpp
@@ -1,0 +1,151 @@
+/*
+
+The MIT License (MIT)
+
+Copyright (c) 2017-2023 Tim Warburton, Noel Chalmers, Jesse Chan, Ali Karakus
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+*/
+
+#include "primitives.hpp"
+
+namespace libp {
+
+namespace prim {
+
+
+template<typename T>
+void runLengthEncode(const dlong N,
+                     const memory<T> v,
+                     dlong& Ngroups,
+                     memory<dlong>& offset) {
+
+  if (N<=0) {
+    Ngroups=0;
+    return;
+  }
+
+  if (N==1) {
+    Ngroups = 1;
+    if (offset.length() < static_cast<size_t>(Ngroups+1)) offset.malloc(Ngroups+1);
+    offset[0] = 0; offset[1] = 1;
+    return;
+  }
+
+  /*Determine how many groups we have*/
+  memory<dlong> diff(N);
+  adjacentDifferenceFlag(N, v, diff);
+  inclusiveScan(N, diff);
+
+  Ngroups = diff[N-1];
+
+  if (offset.length() < static_cast<size_t>(Ngroups+1)) offset.malloc(Ngroups+1);
+
+  offset[0] = 0;
+
+  /*Get the locations where one group transitions to another*/
+  #pragma omp parallel for
+  for (dlong n=1; n<N; ++n) {
+    if(diff[n] - diff[n-1] > 0) {
+      offset[diff[n-1]] = n;
+    }
+  }
+
+  offset[Ngroups] = N;
+}
+
+template
+void runLengthEncode(const dlong N,
+                     const memory<int> v,
+                     dlong& Ngroups,
+                     memory<dlong>& offset);
+
+template
+void runLengthEncode(const dlong N,
+                     const memory<long long int> v,
+                     dlong& Ngroups,
+                     memory<dlong>& offset);
+
+template
+void runLengthEncode(const dlong N,
+                     const memory<float> v,
+                     dlong& Ngroups,
+                     memory<dlong>& offset);
+
+template
+void runLengthEncode(const dlong N,
+                     const memory<double> v,
+                     dlong& Ngroups,
+                     memory<dlong>& offset);
+
+template<typename T>
+void runLengthEncodeConsecutive(const dlong N,
+                                const memory<T> v,
+                                dlong Ngroups,
+                                memory<dlong> offset) {
+
+  if (N<=0) {
+    #pragma omp parallel for
+    for (dlong n=0; n<Ngroups+1; ++n) { offset[n] = 0; }
+    return;
+  }
+
+  offset[0] = 0;
+
+  /*Get the locations where one group transitions to another*/
+  #pragma omp parallel for
+  for (dlong n=0; n<N+1; ++n) {
+    const dlong a = (n==0) ? 0 : v[n-1];
+    const dlong b = (n==N) ? Ngroups : v[n];
+    if(b - a > 0) {
+      for (dlong d=a; d<b;++d ) {
+        offset[d+1] = n;
+      }
+    }
+  }
+}
+
+template
+void runLengthEncodeConsecutive(const dlong N,
+                                const memory<int> v,
+                                dlong Ngroups,
+                                memory<dlong> offset);
+
+template
+void runLengthEncodeConsecutive(const dlong N,
+                                const memory<long long int> v,
+                                dlong Ngroups,
+                                memory<dlong> offset);
+
+template
+void runLengthEncodeConsecutive(const dlong N,
+                                const memory<float> v,
+                                dlong Ngroups,
+                                memory<dlong> offset);
+
+template
+void runLengthEncodeConsecutive(const dlong N,
+                                const memory<double> v,
+                                dlong Ngroups,
+                                memory<dlong> offset);
+
+} //namespace prim
+
+} //namespace libp

--- a/libs/primitives/scan.cpp
+++ b/libs/primitives/scan.cpp
@@ -1,0 +1,128 @@
+/*
+
+The MIT License (MIT)
+
+Copyright (c) 2017-2023 Tim Warburton, Noel Chalmers, Jesse Chan, Ali Karakus
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+*/
+
+#include "primitives.hpp"
+
+namespace libp {
+
+namespace prim {
+
+
+template<typename T>
+void exclusiveScan(const dlong N, memory<T> v) {
+
+  if (N<=0) return;
+
+  T scan_v{0};
+
+#if defined(_OPENMP) && !defined(LIBP_DEBUG)
+  /*This looks totally wrong, but is the only way OpenMP will compile
+  it, and suprisingly does the right thing. Without OpenMP enabled, however
+  this *is* totally wrong*/
+  #pragma omp parallel for reduction(inscan, +:scan_v)
+  for(int n = 0; n < N; ++n){
+    v[n] = scan_v;
+    #pragma omp scan exclusive(scan_v)
+    scan_v += v[n];
+  }
+#else
+  /*Right one for the non-openmp case*/
+  for(int n = 0; n < N; ++n){
+    const T val = v[n];
+    v[n] = scan_v;
+    scan_v += val;
+  }
+#endif
+}
+
+template void exclusiveScan(const dlong N, memory<int> v);
+template void exclusiveScan(const dlong N, memory<long long int> v);
+template void exclusiveScan(const dlong N, memory<float> v);
+template void exclusiveScan(const dlong N, memory<double> v);
+
+
+template<typename T>
+void exclusiveScan(const dlong N, const memory<T> v, memory<T> w) {
+
+  if (N<=0) return;
+
+  T scan_v{0};
+  #pragma omp parallel for reduction(inscan, +:scan_v)
+  for(int n = 0; n < N; ++n){
+    w[n] = scan_v;
+    #pragma omp scan exclusive(scan_v)
+    scan_v += v[n];
+  }
+}
+
+template void exclusiveScan(const dlong N, const memory<int> v, memory<int> w);
+template void exclusiveScan(const dlong N, const memory<long long int> v, memory<long long int> w);
+template void exclusiveScan(const dlong N, const memory<float> v, memory<float> w);
+template void exclusiveScan(const dlong N, const memory<double> v, memory<double> w);
+
+template<typename T>
+void inclusiveScan(const dlong N, memory<T> v) {
+
+  if (N<=0) return;
+
+  T scan_v{0};
+  #pragma omp parallel for reduction(inscan, +:scan_v)
+  for(int n = 0; n < N; ++n){
+    scan_v += v[n];
+    #pragma omp scan inclusive(scan_v)
+    v[n] = scan_v;
+  }
+}
+
+template void inclusiveScan(const dlong N, memory<int> v);
+template void inclusiveScan(const dlong N, memory<long long int> v);
+template void inclusiveScan(const dlong N, memory<float> v);
+template void inclusiveScan(const dlong N, memory<double> v);
+
+
+template<typename T>
+void inclusiveScan(const dlong N, const memory<T> v, memory<T> w) {
+
+  if (N<=0) return;
+
+  T scan_v{0};
+  #pragma omp parallel for reduction(inscan, +:scan_v)
+  for(int n = 0; n < N; ++n){
+    scan_v += v[n];
+    #pragma omp scan inclusive(scan_v)
+    w[n] = scan_v;
+  }
+}
+
+template void inclusiveScan(const dlong N, const memory<int> v, memory<int> w);
+template void inclusiveScan(const dlong N, const memory<long long int> v, memory<long long int> w);
+template void inclusiveScan(const dlong N, const memory<float> v, memory<float> w);
+template void inclusiveScan(const dlong N, const memory<double> v, memory<double> w);
+
+
+} //namespace prim
+
+} //namespace libp

--- a/libs/primitives/select.cpp
+++ b/libs/primitives/select.cpp
@@ -1,0 +1,141 @@
+/*
+
+The MIT License (MIT)
+
+Copyright (c) 2017-2023 Tim Warburton, Noel Chalmers, Jesse Chan, Ali Karakus
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+*/
+
+#include "primitives.hpp"
+
+namespace libp {
+
+namespace prim {
+
+
+template<typename T>
+void select(const dlong N,
+            const memory<T> v,
+            const T& val,
+                  memory<dlong> ids) {
+
+  if (N<=0) return;
+
+  /*Get the locations where v[] = val*/
+  memory<int> predicate(N);
+  #pragma omp parallel for
+  for (dlong n=0; n<N; ++n) {
+    predicate[n] = (v[n] == val) ? 1 : 0;
+  }
+
+  inclusiveScan(N, predicate);
+
+  if (predicate[0]==1) {
+    ids[0] = 0;
+  }
+
+  /*Get the locations where one group transitions to another*/
+  #pragma omp parallel for
+  for (dlong n=1; n<N; ++n) {
+    if(predicate[n] - predicate[n-1] > 0) {
+      ids[predicate[n-1]] = n;
+    }
+  }
+}
+
+template
+void select(const dlong N,
+            const memory<int> v,
+            const int& val,
+            memory<dlong> ids);
+
+template
+void select(const dlong N,
+            const memory<long long int> v,
+            const long long int& val,
+            memory<dlong> ids);
+
+template
+void select(const dlong N,
+            const memory<float> v,
+            const float& val,
+            memory<dlong> ids);
+
+template
+void select(const dlong N,
+            const memory<double> v,
+            const double& val,
+            memory<dlong> ids);
+
+
+template<typename T>
+void unique(const dlong N,
+            const memory<T> v,
+                  dlong& Nunique,
+                  memory<T>& v_unique) {
+
+  if (N<=0) {
+    Nunique=0;
+    return;
+  }
+
+  /*Get the locations where v[] changes value*/
+  memory<int> predicate(N);
+  adjacentDifferenceFlag(N, v, predicate);
+
+  Nunique = count(N, predicate, 1);
+
+  memory<dlong> ids(Nunique);
+  select(N, predicate, 1, ids);
+
+  if (v_unique.length() < static_cast<size_t>(Nunique)) v_unique.malloc(Nunique);
+
+  transformGather(Nunique, ids, v, v_unique);
+}
+
+template
+void unique(const dlong N,
+            const memory<int> v,
+                  dlong& Nunique,
+                  memory<int>& v_unique);
+
+template
+void unique(const dlong N,
+            const memory<long long int> v,
+                  dlong& Nunique,
+                  memory<long long int>& v_unique);
+
+template
+void unique(const dlong N,
+            const memory<float> v,
+                  dlong& Nunique,
+                  memory<float>& v_unique);
+
+template
+void unique(const dlong N,
+            const memory<double> v,
+                  dlong& Nunique,
+                  memory<double>& v_unique);
+
+
+} //namespace prim
+
+} //namespace libp

--- a/libs/primitives/sort.cpp
+++ b/libs/primitives/sort.cpp
@@ -1,0 +1,230 @@
+/*
+
+The MIT License (MIT)
+
+Copyright (c) 2017-2023 Tim Warburton, Noel Chalmers, Jesse Chan, Ali Karakus
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+*/
+
+#include "primitives.hpp"
+
+#ifdef GLIBCXX_PARALLEL
+#include <parallel/algorithm>
+using __gnu_parallel::sort;
+using __gnu_parallel::stable_sort;
+#else
+using std::sort;
+using std::stable_sort;
+#endif
+
+namespace libp {
+
+namespace prim {
+
+
+template <typename T>
+class ZipRef {
+  std::pair<T*, dlong*> ptr;
+
+ public:
+  ZipRef() = delete;
+  ZipRef(const ZipRef& z) = default;
+  ZipRef(ZipRef&& z) = default;
+  ZipRef(T* const val, dlong* const id): ptr{val, id} {}
+
+  ZipRef& operator=(const ZipRef& z)             { return copy_assign(z); }
+  ZipRef& operator=(const std::pair<T, dlong>& val) { return val_assign(val); }
+
+  ZipRef& copy_assign(const ZipRef& z) {
+    *(std::get<0>(ptr)) = *(std::get<0>(z.ptr));
+    *(std::get<1>(ptr)) = *(std::get<1>(z.ptr));
+    return *this;
+  }
+
+  ZipRef& val_assign(const std::pair<T, dlong>& t) {
+    *(std::get<0>(ptr)) = std::get<0>(t);
+    *(std::get<1>(ptr)) = std::get<1>(t);
+    return *this;
+  }
+
+  T val() const {return *(std::get<0>(ptr));}
+
+  operator std::pair<T, dlong>() const { return std::pair(*(std::get<0>(ptr)), *(std::get<1>(ptr))); }
+
+  void swap(const ZipRef& o) const {
+    std::swap(*std::get<0>(ptr), *std::get<0>(o.ptr));
+    std::swap(*std::get<1>(ptr), *std::get<1>(o.ptr));
+  }
+
+  /*Comparisons*/
+  bool operator==(const ZipRef &o) const { return val() == o.val(); }
+  inline friend bool operator==(const ZipRef& r, const std::pair<T, dlong>& t) { return r.val() == std::get<0>(t); }
+  inline friend bool operator==(const std::pair<T, dlong>& t, const ZipRef& r) { return std::get<0>(t) == r.val(); }
+  bool operator<=(const ZipRef &o) const { return val() <= o.val(); }
+  inline friend bool operator<=(const ZipRef& r, const std::pair<T, dlong>& t) { return r.val() <= std::get<0>(t); }
+  inline friend bool operator<=(const std::pair<T, dlong>& t, const ZipRef& r) { return std::get<0>(t) <= r.val(); }
+  bool operator>=(const ZipRef &o) const { return val() >= o.val(); }
+  inline friend bool operator>=(const ZipRef& r, const std::pair<T, dlong>& t) { return r.val() >= std::get<0>(t); }
+  inline friend bool operator>=(const std::pair<T, dlong>& t, const ZipRef& r) { return std::get<0>(t) >= r.val(); }
+  bool operator!=(const ZipRef &o) const { return val() != o.val(); }
+  inline friend bool operator!=(const ZipRef& r, const std::pair<T, dlong>& t) { return r.val() != std::get<0>(t); }
+  inline friend bool operator!=(const std::pair<T, dlong>& t, const ZipRef& r) { return std::get<0>(t) != r.val(); }
+  bool operator< (const ZipRef &o) const { return val() <  o.val(); }
+  inline friend bool operator<(const ZipRef& r, const std::pair<T, dlong>& t) { return r.val() <  std::get<0>(t); }
+  inline friend bool operator<(const std::pair<T, dlong>& t, const ZipRef& r) { return std::get<0>(t) <  r.val(); }
+  bool operator> (const ZipRef &o) const { return val() >  o.val(); }
+  inline friend bool operator>(const ZipRef& r, const std::pair<T, dlong>& t) { return r.val() >  std::get<0>(t); }
+  inline friend bool operator>(const std::pair<T, dlong>& t, const ZipRef& r) { return std::get<0>(t) >  r.val(); }
+};
+
+template<typename T>
+class ZipIter {
+  std::pair<T*, dlong*> it;
+
+ public:
+  using iterator_category = typename std::iterator_traits<T*>::iterator_category;
+  using difference_type   = typename std::iterator_traits<T*>::difference_type;
+  using value_type        = std::pair<typename std::iterator_traits<T*>::value_type, dlong>;
+  using pointer           = std::pair<typename std::iterator_traits<T*>::pointer, dlong*>;
+  using reference         = ZipRef<typename std::iterator_traits<T*>::value_type>;
+
+  ZipIter() = default;
+  ZipIter(const ZipIter &rhs) = default;
+  ZipIter(ZipIter&& rhs) = default;
+  ZipIter(T* val, dlong* id): it(std::move(val), std::move(id)) {}
+
+  ZipIter& operator=(const ZipIter& rhs) = default;
+  ZipIter& operator=(ZipIter&& rhs) = default;
+
+  ZipIter& operator+=(const difference_type d) { std::get<0>(it)+=d; std::get<1>(it)+=d; return *this; }
+  ZipIter& operator-=(const difference_type d) { std::get<0>(it)-=d; std::get<1>(it)-=d; return *this; }
+
+  reference operator* () const { return reference(std::get<0>(it), std::get<1>(it)); }
+  pointer   operator->() const { return pointer(std::get<0>(it), std::get<1>(it)); }
+  reference operator[](difference_type rhs) const {return *(operator+(rhs));}
+
+  ZipIter& operator++() { return operator+=(1); }
+  ZipIter& operator--() { return operator+=(-1); }
+  ZipIter operator++(dlong) {ZipIter tmp(*this); operator++(); return tmp;}
+  ZipIter operator--(dlong) {ZipIter tmp(*this); operator--(); return tmp;}
+
+  difference_type operator-(const ZipIter& rhs) const {return std::get<0>(it)-std::get<0>(rhs.it);}
+  ZipIter operator+(const difference_type d) const {ZipIter tmp(*this); tmp += d; return tmp;}
+  ZipIter operator-(const difference_type d) const {ZipIter tmp(*this); tmp -= d; return tmp;}
+  inline friend ZipIter operator+(const difference_type d, const ZipIter& z) {return z+d;}
+  inline friend ZipIter operator-(const difference_type d, const ZipIter& z) {return z-d;}
+
+  bool operator==(const ZipIter& rhs) const {return it == rhs.it;}
+  bool operator<=(const ZipIter& rhs) const {return it <= rhs.it;}
+  bool operator>=(const ZipIter& rhs) const {return it >= rhs.it;}
+  bool operator!=(const ZipIter& rhs) const {return it != rhs.it;}
+  bool operator< (const ZipIter& rhs) const {return it <  rhs.it;}
+  bool operator> (const ZipIter& rhs) const {return it >  rhs.it;}
+};
+
+template<typename T>
+class Zip {
+  std::pair<T*, dlong*> zip;
+  size_t len;
+
+ public:
+  Zip() = delete;
+  Zip(const Zip& z) = default;
+  Zip(Zip&& z) = default;
+  Zip(memory<T>& val, memory<dlong>& ids, size_t len_) : zip {val.ptr(), ids.ptr()}, len(len_) {}
+
+  ZipIter<T> begin() {return ZipIter(std::get<0>(zip), std::get<1>(zip));}
+  ZipIter<T> end() {return ZipIter(std::get<0>(zip)+len, std::get<1>(zip)+len);}
+};
+
+template<typename T>
+void swap(const ZipRef<T>& a, const ZipRef<T>& b) {
+  a.swap(b);
+}
+
+
+template<typename T>
+void sort(const dlong N, memory<T> v) {
+	if (N<=0) return;
+	::sort(v.ptr(), v.ptr() + N);
+}
+
+template void sort(const dlong N, memory<int> v);
+template void sort(const dlong N, memory<long long int> v);
+template void sort(const dlong N, memory<float> v);
+template void sort(const dlong N, memory<double> v);
+
+template<typename T>
+void sort(const dlong N, memory<T> v, memory<dlong> sortIds) {
+
+	if (N<=0) return;
+
+	/*Write initial ordering*/
+	#pragma omp parallel for
+	for (dlong n=0; n<N; ++n) { sortIds[n] = n; }
+
+	/*Zip vals and ids together*/
+	Zip<T> zip(v, sortIds, N);
+
+	/*Simultaneous sort*/
+	::sort(zip.begin(), zip.end());
+}
+
+template void sort(const dlong N, memory<int> v          , memory<dlong> sortIds);
+template void sort(const dlong N, memory<long long int> v, memory<dlong> sortIds);
+template void sort(const dlong N, memory<float> v        , memory<dlong> sortIds);
+template void sort(const dlong N, memory<double> v       , memory<dlong> sortIds);
+
+template<typename T>
+void stableSort(const dlong N, memory<T> v) {
+  if (N<=0) return;
+  ::stable_sort(v.ptr(), v.ptr() + N);
+}
+
+template void stableSort(const dlong N, memory<int> v);
+template void stableSort(const dlong N, memory<long long int> v);
+template void stableSort(const dlong N, memory<float> v);
+template void stableSort(const dlong N, memory<double> v);
+
+template<typename T>
+void stableSort(const dlong N, memory<T> v, memory<dlong> sortIds) {
+
+  if (N<=0) return;
+
+  /*Write initial ordering*/
+  #pragma omp parallel for
+  for (dlong n=0; n<N; ++n) { sortIds[n] = n; }
+
+  /*Zip vals and ids together*/
+  Zip<T> zip(v, sortIds, N);
+
+  /*Simultaneous sort*/
+  ::stable_sort(zip.begin(), zip.end());
+}
+
+template void stableSort(const dlong N, memory<int> v          , memory<dlong> sortIds);
+template void stableSort(const dlong N, memory<long long int> v, memory<dlong> sortIds);
+template void stableSort(const dlong N, memory<float> v        , memory<dlong> sortIds);
+template void stableSort(const dlong N, memory<double> v       , memory<dlong> sortIds);
+
+} //namespace prim
+
+} //namespace libp

--- a/libs/primitives/transform.cpp
+++ b/libs/primitives/transform.cpp
@@ -1,0 +1,75 @@
+/*
+
+The MIT License (MIT)
+
+Copyright (c) 2017-2023 Tim Warburton, Noel Chalmers, Jesse Chan, Ali Karakus
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+*/
+
+#include "primitives.hpp"
+
+namespace libp {
+
+namespace prim {
+
+
+template<typename T>
+void transformGather(const dlong N,
+                     const memory<dlong> ids,
+                     const memory<T> v,
+                           memory<T> w) {
+
+  if (N<=0) return;
+
+  #pragma omp parallel for
+  for (dlong n=0; n<N; ++n) {
+    w[n] = v[ids[n]];
+  }
+}
+
+template void transformGather(const dlong N, const memory<dlong> id, const memory<int> v, memory<int> w);
+template void transformGather(const dlong N, const memory<dlong> id, const memory<long long int> v, memory<long long int> w);
+template void transformGather(const dlong N, const memory<dlong> id, const memory<float> v, memory<float> w);
+template void transformGather(const dlong N, const memory<dlong> id, const memory<double> v, memory<double> w);
+
+
+template<typename T>
+void transformScatter(const dlong N,
+                      const memory<dlong> ids,
+                      const memory<T> v,
+                            memory<T> w) {
+
+  if (N<=0) return;
+
+  #pragma omp parallel for
+  for (dlong n=0; n<N; ++n) {
+    w[ids[n]] = v[n];
+  }
+}
+
+template void transformScatter(const dlong N, const memory<dlong> id, const memory<int> v, memory<int> w);
+template void transformScatter(const dlong N, const memory<dlong> id, const memory<long long int> v, memory<long long int> w);
+template void transformScatter(const dlong N, const memory<dlong> id, const memory<float> v, memory<float> w);
+template void transformScatter(const dlong N, const memory<dlong> id, const memory<double> v, memory<double> w);
+
+} //namespace prim
+
+} //namespace libp

--- a/makefile
+++ b/makefile
@@ -88,7 +88,7 @@ DEFINES =${HIPBONE_DEFINES}
 HB_CXXFLAGS=${HIPBONE_CXXFLAGS} ${DEFINES} ${INCLUDES}
 
 #link libraries
-LIBS=-L${HIPBONE_LIBS_DIR} -lmesh -logs -lcore \
+LIBS=-L${HIPBONE_LIBS_DIR} -lmesh -logs -lprim -lcore \
      ${HIPBONE_LIBS}
 
 #link flags
@@ -121,9 +121,9 @@ endif
 
 hipbone_libs: ${OCCA_DIR}/lib/libocca.so
 ifneq (,${verbose})
-	${MAKE} -C ${HIPBONE_LIBS_DIR} mesh ogs core verbose=${verbose}
+	${MAKE} -C ${HIPBONE_LIBS_DIR} mesh ogs core prim verbose=${verbose}
 else
-	@${MAKE} -C ${HIPBONE_LIBS_DIR} mesh ogs core --no-print-directory
+	@${MAKE} -C ${HIPBONE_LIBS_DIR} mesh ogs core prim --no-print-directory
 endif
 
 ${OCCA_DIR}/lib/libocca.so:


### PR DESCRIPTION
This is a chunky PR, but it's been pre-tested in [dawgs](https://github.com/paranumal/dawgs/tree/feature/primitives).

Adds a library of parallel primitives. These primitives are parallelized via OpenMP, but could in future also be done on the device with deviceMemory and kernels. 

The ogs setup has been re-written to use these parallel primitives throughout, essentially making the ogs setup fully parallelized. 

This has improved setup times roughly in proportion to the number of memory channels on the CPU. I.e. for the full single process HipBone run, I observe a 2x speedup in setup time on my workstation, and a ~7x speedup on a Lockhart node. For the 8 process run on a Lockhart node, I'm still seeing a ~3x speedup in the ogs setup despite the extra processes utilizing the resources. 

Performance of the FOM region was unaffected in performance tests.