### PR TITLE
Use inline static const to workaround OpenMPI when compiling with g++-12

### DIFF
--- a/include/comm.hpp
+++ b/include/comm.hpp
@@ -100,13 +100,13 @@ class comm_t {
 
   /*Predefined ops*/
   using op_t = MPI_Op;
-  static constexpr op_t Max  = MPI_MAX;
-  static constexpr op_t Min  = MPI_MIN;
-  static constexpr op_t Sum  = MPI_SUM;
-  static constexpr op_t Prod = MPI_PROD;
-  static constexpr op_t And  = MPI_LAND;
-  static constexpr op_t Or   = MPI_LOR;
-  static constexpr op_t Xor  = MPI_LXOR;
+  inline static const op_t Max  = MPI_MAX;
+  inline static const op_t Min  = MPI_MIN;
+  inline static const op_t Sum  = MPI_SUM;
+  inline static const op_t Prod = MPI_PROD;
+  inline static const op_t And  = MPI_LAND;
+  inline static const op_t Or   = MPI_LOR;
+  inline static const op_t Xor  = MPI_LXOR;
 
   /*libp::memory send*/
   template <template<typename> class mem, typename T>


### PR DESCRIPTION
Issue arises because it looks like OpenMPI is using a static_cast rather than a reinterpret_cast. Example of error:

<pre>
                 from core/linAlg.cpp:27:
/opt/ompi-5.0.0rc12/include/mpi.h:423:47: error: cast from ‘void*’ is not allowed
  423 | #define OMPI_PREDEFINED_GLOBAL(type, global) (static_cast<type> (static_cast<void *> (&(global))))
      |                                              ~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
</pre>

This is probably an example of the other folks doing it wrong, but this gets us running with both gcc 11 and gcc 12 since this PR is valid c++17.