### PR TITLE
Add convenience file to run multiple poly orders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 !*/*/makefile
 !*/*/Makefile
 !LICENSE
+!hipBone_poly
 
 *.o
 *.a

--- a/hipBone_poly
+++ b/hipBone_poly
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -eo pipefail
+
+nonpoly_args=()
+poly_args=""
+
+while [[ $# -gt 0 ]]
+do
+  case $1 in
+    -p)
+      poly_args="$2"
+      shift
+      shift
+      ;;
+    -v)  # -v doesn't take a value, handle separately
+      nonpoly_args+=("$1")
+      shift
+      ;;
+    *)
+      nonpoly_args+=("$1")
+      nonpoly_args+=("$2")
+      shift
+      shift
+      ;;
+  esac
+done
+
+OLD_IFS=$IFS
+IFS=,
+for p in ${poly_args}  # comma is the delimiter
+do
+  ./hipBone -p $p ${nonpoly_args[@]}
+done


### PR DESCRIPTION
This was requested to align more closely with the original Nekbone benchmark which automatically ran several polynomial orders.

Example invocation:

```
./hipBone_poly <usual hipBone args> -p p1,p2,p3 <more hipBone args>
```

This will execute, in order:

```
./hipBone_poly <usual hipBone args> -p p1 <more hipBone args>
./hipBone_poly <usual hipBone args> -p p2 <more hipBone args>
./hipBone_poly <usual hipBone args> -p p3 <more hipBone args>
```