### PR TITLE
Fix hipBone segfault when running with rocprof

### DIFF
--- a/make.top
+++ b/make.top
@@ -46,7 +46,7 @@ export HIPBONE_LD = mpic++
 
 export HIPBONE_INCLUDES=-I${HIPBONE_INCLUDE_DIR} -I${OCCA_DIR}/include
 export HIPBONE_LIBS= ${HIPBONE_BLAS_LIB}  \
-                     -Wl,-rpath,$(OCCA_DIR)/lib -Wl,-rpath,${OPENBLAS_DIR} -L$(OCCA_DIR)/lib -locca
+                     -Wl,-rpath,$(OCCA_DIR)/lib -Wl,-rpath,${OPENBLAS_DIR} -L$(OCCA_DIR)/lib -locca -lhwloc
 
 ifneq (,${debug})
   export HIPBONE_CFLAGS=-O0 -g -Wall -Wshadow -Wno-unused-function -Wno-unknown-pragmas


### PR DESCRIPTION
Running hipbone with rocprof segfaults.

The current assumption in the code was to assume the output from popen is a single line.  fgets only processes a single line (up to \n).  When the popen (shell) invocation is clobbered by roctracer output, what the fgets call sees is the first line which is the roctracer output, and NOT the output from the pipe, which comes in a later line.  It is not clear to me why roctracer output from the parent shell is caught in the output of the child shell.  I suppose there is only one stdout and so when two things write to it, you have some indeterminate ordering.  This might explain why you don't see it in other OSs; perhaps they way shells are handled takes more "time" on a rhel system for a reason I don't know, and that's why we see the behaviour we see.

There are multiple ways to skin this cat.  I picked one that consumes an external software dependency.  The other solutions involved string parsing in C++ which is its own can of worms.