### PR TITLE
Fix uninitialised LDS variable

### DIFF
--- a/okl/hipBoneAx.okl
+++ b/okl/hipBoneAx.okl
@@ -548,10 +548,8 @@ SOFTWARE.
 
       for(int j=0;j<16;++j;@inner(1)){
         for(int i=0;i<16;++i;@inner(0)){
-          if (i<p_Nq && j < p_Nq) {
-            // share u(:,:,k)
-            s_q[j][i] = r_u[k];
-          }
+          // share u(:,:,k)
+          s_q[j][i] = r_u[k];
         }
       }
 


### PR DESCRIPTION
In rare circumstances, hipBone was producing 'nan' values for r norm.  These cases were only reproducible on orders between 11 and 14 and on MI300 (and presumably MI200) parts.  That is precisely when KERNEL_NUMBER==3 and we use the MFMA builtins in the operator application kernel.

The branch around s_q guarded against the unused thread in the threadblock from initialising s_q, which is then later read by the MFMA builtin.  Removing the branch causes the s_q variable to be initialised to r_u on every thread, and r_u is initialised to zero on the unused threads in the threadblock.